### PR TITLE
feat: Customizable output for aws-ct-timeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.0.1"
 repository = "https://github.com/Yamato-Security/suzaku"
 authors = ["Yamato Security @SecurityYamato"]
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.85.1"
 include = ["src/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]
 
 [dependencies]
-clap = {version = "4.5.31", features = ["derive", "env"]}
-sigma-rust = "0.5.1"
-serde_json = "1.0.139"
+clap = {version = "4.5.*", features = ["derive", "env"]}
+sigma-rust = "0.5.*"
+serde_json = "1.0.*"
 flate2 = { version = "1.1.*", features = ["zlib-rs"], default-features = false }
 csv = "1.3.*"
 indicatif = "*"

--- a/config/aws_ct_timeline_default_profile.txt
+++ b/config/aws_ct_timeline_default_profile.txt
@@ -1,0 +1,7 @@
+Timestamp,awsLog.eventTime
+RuleTitle,sigmaRule.title
+Level,sigmaRule.level
+AWS-Region,awsLog.awsRegion
+EventName,awsLog.eventName
+EventSource,awsLog.eventSource
+EventID,awsLog.eventID

--- a/src/aws_detect.rs
+++ b/src/aws_detect.rs
@@ -1,40 +1,32 @@
 use crate::rules;
 use crate::scan::{get_content, load_json_from_file, process_events_from_dir};
 use crate::util::{get_writer, s};
+use sigma_rust::{Event, Rule};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 pub fn aws_detect(directory: &Option<PathBuf>, file: &Option<PathBuf>, output: &Option<PathBuf>) {
+    let profile = load_profile("config/aws_ct_timeline_default_profile.txt");
     let rules = rules::load_rules_from_dir("rules");
     println!("Total detection rules: {:?}", rules.len());
 
     let mut wtr = get_writer(output);
-    let csv_header = vec![
-        "eventTime",
-        "Rule Title",
-        "Level",
-        "awsRegion",
-        "eventName",
-        "eventSource",
-        "eventID",
-    ];
-    wtr.write_record(csv_header).unwrap();
+    let csv_header: Vec<&str> = profile.iter().map(|(k, _v)| k.as_str()).collect();
+    wtr.write_record(&csv_header).unwrap();
 
     let scan_by_all_rules = |event| {
         for rule in &rules {
             if rule.is_match(&event) {
-                let record = vec![
-                    s(format!("{:?}", event.get("eventTime").unwrap())),
-                    rule.title.to_string(),
-                    format!("{:?}", rule.level.as_ref().unwrap()),
-                    s(format!("{:?}", event.get("awsRegion").unwrap())),
-                    s(format!("{:?}", event.get("eventName").unwrap())),
-                    s(format!("{:?}", event.get("eventSource").unwrap())),
-                    s(format!("{:?}", event.get("eventID").unwrap())),
-                ];
+                let record: Vec<String> = profile
+                    .iter()
+                    .map(|(_k, v)| get_value_from_event(v, &event, rule))
+                    .collect();
                 wtr.write_record(&record).unwrap();
             }
         }
     };
+
     if let Some(d) = directory {
         process_events_from_dir(d, output.is_some(), scan_by_all_rules).unwrap();
     } else if let Some(f) = file {
@@ -45,4 +37,41 @@ pub fn aws_detect(directory: &Option<PathBuf>, file: &Option<PathBuf>, output: &
         }
     }
     wtr.flush().ok();
+}
+
+fn load_profile(file_path: &str) -> Vec<(String, String)> {
+    let file = File::open(file_path).expect("Unable to open profile file");
+    let reader = BufReader::new(file);
+    let mut profile = vec![];
+
+    for line in reader.lines() {
+        let line = line.expect("Unable to read line");
+        let parts: Vec<&str> = line.split(',').collect();
+        if parts.len() == 2 {
+            profile.push((String::from(parts[0]), String::from(parts[1])));
+        }
+    }
+    profile
+}
+
+fn get_value_from_event(key: &str, event: &Event, rule: &Rule) -> String {
+    if key.starts_with("awsLog.") {
+        let key = key.replace("awsLog.", "");
+        if let Some(value) = event.get(key.as_str()) {
+            s(format!("{:?}", value))
+        } else {
+            "".to_string()
+        }
+    } else if key.starts_with("sigmaRule.") {
+        let key = key.replace("sigmaRule.", "");
+        if key == "title" {
+            rule.title.to_string()
+        } else if key == "level" {
+            format!("{:?}", rule.level.as_ref().unwrap())
+        } else {
+            "".to_string()
+        }
+    } else {
+        "".to_string()
+    }
 }


### PR DESCRIPTION
## What Changed
- Closed #10 

## Test
```
% cat config/aws_ct_timeline_default_profile.txt
Timestamp,awsLog.eventTime
RuleTitle,sigmaRule.title
Level,sigmaRule.level
AWS-Region,awsLog.awsRegion
EventName,awsLog.eventName
EventSource,awsLog.eventSource
EventID,awsLog.eventID
EventType,awsLog.eventType
UserAgent,awsLog.userAgent
AccountID,awsLog.userIdentity.accountId
```

```
/suzaku aws-ct-timeline -d ~/Downloads/flaws_cloudtrail_logs -o timeline.csv

┏━━━┳┓ ┏┳━━━━┳━━━┳┓┏━┳┓ ┏┓
┃┏━┓┃┃ ┃┣━━┓ ┃┏━┓┃┃┃┏┫┃ ┃┃
┃┗━━┫┃ ┃┃ ┏┛┏┫┃ ┃┃┗┛┛┃┃ ┃┃
┗━━┓┃┃ ┃┃┏┛┏┛┃┗━┛┃┏┓┓┃┃ ┃┃
┃┗━┛┃┗━┛┣┛ ┗━┫┏━┓┃┃┃┗┫┗━┛┃
┗━━━┻━━━┻━━━━┻┛ ┗┻┛┗━┻━━━┛
   by Yamato Security

Start time: 2025/03/21 20:56

Total detection rules: 46
Total log files: 20
Total file size: 251.7 MB

[00:00:37] 20 / 20   [========================================] 100%

Scanning finished.                                                                                                                                                        Elapsed time: 00:00:37
```
<img width="1710" alt="スクリーンショット 2025-03-21 20 58 43" src="https://github.com/user-attachments/assets/5adeadfd-f6e2-4caf-8e38-108c086be4ee" />


I’d appreciate it if you could check it when you have time🙏
