### PR TITLE
fix: GitHub Actions release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           mkdir -p release-binaries
           Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
+          Copy-Item -Recurse -Path ./config -Destination release-binaries/
           Copy-Item -Recurse -Path ./rules -Destination release-binaries/
           Copy-Item -Recurse -Path ./art -Destination release-binaries/
           switch ("${{ matrix.info.os }}") {
@@ -102,6 +103,7 @@ jobs:
         if: contains(matrix.info.os, 'windows') == false
         run: |
           mkdir -p release-binaries
+          cp -r ./config release-binaries/config
           cp -r ./rules release-binaries/rules
           cp -r ./art release-binaries/art
           case ${{ matrix.info.os }} in


### PR DESCRIPTION
## What Changed
I fixed an issue where the GitHub Actions package was failing due to an error.

## Evidence
https://github.com/Yamato-Security/suzaku/actions/runs/14094666291
<img width="1710" alt="スクリーンショット 2025-03-27 7 32 09" src="https://github.com/user-attachments/assets/bc102596-43b3-4a9b-bf11-f39a2c312dc0" />

I’d appreciate it if you could check it when you have time🙏
