### PR TITLE
feat: update GitHub Actions for release to create Windows packages and fix the update-rules issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
             target: "i686-pc-windows-msvc",
           }
           - {
+            os: "windows-2019",
+            target: "aarch64-pc-windows-msvc",
+          }
+          - {
             os: "ubuntu-latest",
             target: "x86_64-unknown-linux-gnu",
           }
@@ -93,6 +97,7 @@ jobs:
         shell: pwsh
         run: |
           mkdir -p release-binaries
+          Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
           Copy-Item -Recurse -Path ./config -Destination release-binaries/
           Copy-Item -Recurse -Path ./art -Destination release-binaries/
           Remove-Item -Path ./suzaku-rules/.gitignore -Force
@@ -102,11 +107,12 @@ jobs:
           Copy-Item -Recurse -Path ./suzaku-rules/ -Destination release-binaries/rules -Force
           switch ("${{ matrix.info.os }}") {
               "windows-latest" { 
-                  Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
                   mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x64.exe 
               }
               "windows-2022" { 
-                  Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
+                  mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe 
+              }
+              "windows-2019" { 
                   mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe 
               }
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,7 @@ jobs:
         shell: pwsh
         run: |
           mkdir -p release-binaries
-          dir ./target/
-          dir ./target/${{ matrix.info.target }}/release/
-          Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
+          Copy-Item -Path ./target/${{ matrix.info.target }}/release/suzaku.exe -Destination release-binaries/
           Copy-Item -Recurse -Path ./config -Destination release-binaries/
           Copy-Item -Recurse -Path ./art -Destination release-binaries/
           Remove-Item -Path ./suzaku-rules/.gitignore -Force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,18 @@ jobs:
     strategy:
       matrix:
         info:
-#          - {
-#            os: "windows-latest",
-#            target: "x86_64-pc-windows-msvc",
-#          }
-#          - {
-#            os: "windows-2022",
-#            target: "i686-pc-windows-msvc",
-#          }
-#          - {
-#            os: "windows-2019",
-#            target: "aarch64-pc-windows-msvc",
-#          }
+          - {
+            os: "windows-latest",
+            target: "x86_64-pc-windows-msvc",
+          }
+          - {
+            os: "windows-2022",
+            target: "i686-pc-windows-msvc",
+          }
+          - {
+            os: "windows-2019",
+            target: "aarch64-pc-windows-msvc",
+          }
           - {
             os: "ubuntu-latest",
             target: "x86_64-unknown-linux-gnu",
@@ -56,6 +56,14 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch_or_tag }}
           submodules: 'true'
+
+      - name: Clone hayabusa rule repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: Yamato-Security/suzaku-rules
+          fetch-depth: 0
+          path: suzaku-rules
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -91,8 +99,12 @@ jobs:
           mkdir -p release-binaries
           Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
           Copy-Item -Recurse -Path ./config -Destination release-binaries/
-          Copy-Item -Recurse -Path ./rules -Destination release-binaries/
           Copy-Item -Recurse -Path ./art -Destination release-binaries/
+          Remove-Item -Path ./suzaku-rules/.gitignore -Force
+          Remove-Item -Path ./suzaku-rules/*.md -Force
+          Remove-Item -Path ./suzaku-rules/.github -Recurse -Force
+          Remove-Item -Path ./suzaku-rules/doc -Recurse -Force
+          Copy-Item -Recurse -Path ./suzaku-rules/ -Destination release-binaries/rules -Force
           switch ("${{ matrix.info.os }}") {
               "windows-latest" { mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x64.exe }
               "windows-2022" { mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe }
@@ -104,8 +116,12 @@ jobs:
         run: |
           mkdir -p release-binaries
           cp -r ./config release-binaries/config
-          cp -r ./rules release-binaries/rules
           cp -r ./art release-binaries/art
+          rm -f ./suzaku-rules/.gitignore
+          rm -f ./suzaku-rules/*.md
+          rm -rf ./suzaku-rules/.github
+          rm -rf ./suzaku-rules/doc
+          cp -r ./suzaku-rules/. release-binaries/rules
           case ${{ matrix.info.os }} in
             'ubuntu-latest')
                 cp ./target/x86_64-unknown-linux-gnu/release/suzaku release-binaries/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,6 @@ jobs:
             target: "i686-pc-windows-msvc",
           }
           - {
-            os: "windows-2019",
-            target: "aarch64-pc-windows-msvc",
-          }
-          - {
             os: "ubuntu-latest",
             target: "x86_64-unknown-linux-gnu",
           }
@@ -108,7 +104,6 @@ jobs:
           switch ("${{ matrix.info.os }}") {
               "windows-latest" { mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x64.exe }
               "windows-2022" { mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe }
-              "windows-2019" { mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-aarch64.exe }
           }
 
       - name: Package and Zip - Unix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
                   mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe 
               }
               "windows-2019" { 
-                  mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe 
+                  mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-aarch64.exe 
               }
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,6 @@ jobs:
         shell: pwsh
         run: |
           mkdir -p release-binaries
-          Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
           Copy-Item -Recurse -Path ./config -Destination release-binaries/
           Copy-Item -Recurse -Path ./art -Destination release-binaries/
           Remove-Item -Path ./suzaku-rules/.gitignore -Force
@@ -102,8 +101,14 @@ jobs:
           Remove-Item -Path ./suzaku-rules/doc -Recurse -Force
           Copy-Item -Recurse -Path ./suzaku-rules/ -Destination release-binaries/rules -Force
           switch ("${{ matrix.info.os }}") {
-              "windows-latest" { mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x64.exe }
-              "windows-2022" { mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe }
+              "windows-latest" { 
+                  Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
+                  mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x64.exe 
+              }
+              "windows-2022" { 
+                  Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
+                  mv release-binaries/suzaku.exe release-binaries/suzaku-${{ github.event.inputs.release_ver }}-win-x86.exe 
+              }
           }
 
       - name: Package and Zip - Unix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,14 @@ jobs:
         shell: pwsh
         run: |
           mkdir -p release-binaries
+          dir ./target/
+          dir ./target/${{ matrix.info.target }}/release/
           Copy-Item -Path ./target/release/suzaku.exe -Destination release-binaries/
           Copy-Item -Recurse -Path ./config -Destination release-binaries/
           Copy-Item -Recurse -Path ./art -Destination release-binaries/
           Remove-Item -Path ./suzaku-rules/.gitignore -Force
           Remove-Item -Path ./suzaku-rules/*.md -Force
           Remove-Item -Path ./suzaku-rules/.github -Recurse -Force
-          Remove-Item -Path ./suzaku-rules/doc -Recurse -Force
           Copy-Item -Recurse -Path ./suzaku-rules/ -Destination release-binaries/rules -Force
           switch ("${{ matrix.info.os }}") {
               "windows-latest" { 
@@ -126,7 +127,6 @@ jobs:
           rm -f ./suzaku-rules/.gitignore
           rm -f ./suzaku-rules/*.md
           rm -rf ./suzaku-rules/.github
-          rm -rf ./suzaku-rules/doc
           cp -r ./suzaku-rules/. release-binaries/rules
           case ${{ matrix.info.os }} in
             'ubuntu-latest')


### PR DESCRIPTION
## What Changed

- Added windows packages
- Added suzaku-rules clone process explicitly
   - to fix  https://github.com/Yamato-Security/suzaku/pull/28#pullrequestreview-2745110812 issue

## Evidence
### release-automation
- https://github.com/Yamato-Security/suzaku/actions/runs/14311151409

I’d appreciate it if you could check it when you have time🙏