### PR TITLE
feat: add output-type option/ remove T and Z from timesamp/ update bytesize crate to2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayvec"
@@ -138,9 +138,9 @@ checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "jobserver",
  "libc",
@@ -175,9 +175,9 @@ checksum = "bd1b64030216239a2e7c364b13cd96a2097ebf0dfe5025f2dedee14a23f2ab60"
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -367,9 +367,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -518,14 +518,15 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -680,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -715,10 +716,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -758,9 +760,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libgit2-sys"
@@ -802,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
 dependencies = [
  "zlib-rs",
 ]
@@ -829,9 +831,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -851,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -881,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -925,9 +927,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
@@ -963,9 +965,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
 dependencies = [
  "cc",
 ]
@@ -1026,18 +1028,18 @@ checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1070,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -1135,22 +1137,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "log",
  "once_cell",
@@ -1207,18 +1209,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1276,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1322,7 +1324,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suzaku"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "bytesize",
  "chrono",
@@ -1347,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1376,7 +1378,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -1405,7 +1407,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -1465,9 +1467,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0351ca625c7b41a8e4f9bb6c5d9755f67f62c2187ebedecacd9974674b271d"
+checksum = "b7a3e9af6113ecd57b8c63d3cd76a385b2e3881365f1f489e54f49801d0c83ea"
 dependencies = [
  "base64",
  "flate2",
@@ -1483,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae239d0a3341aebc94259414d1dc67cfce87d41cbebc816772c91b77902fafa4"
+checksum = "fadf18427d33828c311234884b7ba2afb57143e6e7e69fda7ee883b624661e36"
 dependencies = [
  "base64",
  "http",
@@ -1665,18 +1667,62 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1922,6 +1968,6 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytesize"
-version = "1.3.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "suzaku"
-version = "0.0.1"
+version = "0.1.0"
 repository = "https://github.com/Yamato-Security/suzaku"
 authors = ["Yamato Security @SecurityYamato"]
 edition = "2024"
-rust-version = "1.85.1"
+rust-version = "1.86.0"
 include = ["src/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,24 +8,24 @@ rust-version = "1.85.1"
 include = ["src/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]
 
 [dependencies]
-clap = {version = "4.5.*", features = ["derive", "env"]}
-sigma-rust = "0.5.*"
-serde_json = "1.0.*"
-flate2 = { version = "1.1.*", features = ["zlib-rs"], default-features = false }
-csv = "1.3.*"
-indicatif = "*"
-colored = "2"
-bytesize = "1.*"
+bytesize = "2.*"
 chrono = "0.4.*"
+clap = {version = "4.5.*", features = ["derive", "env"]}
+colored = "2"
 comfy-table = "7.*"
-krapslog = "0.6"
-terminal_size = "0.4.*"
-termcolor = "*"
-num-format = "0.4.*"
 console = "0.*"
+csv = "1.3.*"
+flate2 = { version = "1.1.*", features = ["zlib-rs"], default-features = false }
 git2="*"
-ureq="*"
 hashbrown="*"
+indicatif = "*"
+krapslog = "0.6"
+num-format = "0.4.*"
+serde_json = "1.0.*"
+sigma-rust = "0.5.*"
+termcolor = "*"
+terminal_size = "0.4.*"
+ureq="*"
 
 [target.'cfg(unix)'.dependencies] #Mac and Linux
 openssl = { version = "*", features = ["vendored"] }  #vendored is needed to compile statically.

--- a/src/aws_detect.rs
+++ b/src/aws_detect.rs
@@ -11,7 +11,7 @@ use krapslog::{build_sparkline, build_time_markers};
 use num_format::{Locale, ToFormattedString};
 use sigma_rust::{Event, Rule};
 use std::cmp::min;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::io::{BufWriter, Write};
@@ -78,7 +78,7 @@ fn write_record(
 
     // JSON出力
     if let Some(writer) = json_writer {
-        let mut json_record: HashMap<String, String> = HashMap::new();
+        let mut json_record: BTreeMap<String, String> = BTreeMap::new();
         for (k, v) in profile {
             let value = get_value_from_event(v, event, rule);
             json_record.insert(k.clone(), value.to_string());
@@ -92,7 +92,7 @@ fn write_record(
 
     // JSONL出力
     if let Some(writer) = jsonl_writer {
-        let mut json_record: HashMap<String, String> = HashMap::new();
+        let mut json_record: BTreeMap<String, String> = BTreeMap::new();
         for (k, v) in profile {
             let value = get_value_from_event(v, event, rule);
             json_record.insert(k.clone(), value.to_string());

--- a/src/aws_detect.rs
+++ b/src/aws_detect.rs
@@ -1,19 +1,20 @@
+use crate::cmd::{AwsCtTimelineOptions, CommonOptions};
 use crate::rules;
 use crate::scan::{get_content, load_json_from_file, process_events_from_dir};
-use crate::util::{get_writer, p, s};
+use crate::util::{get_json_writer, get_writer, p, s};
 use chrono::{DateTime, Utc};
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
 use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Cell, Table, TableComponent};
+use csv::Writer;
 use krapslog::{build_sparkline, build_time_markers};
 use num_format::{Locale, ToFormattedString};
 use sigma_rust::{Event, Rule};
 use std::cmp::min;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::Write;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::io::{BufWriter, Write};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 use terminal_size::{Width, terminal_size};
 
@@ -29,17 +30,83 @@ struct DetectionSummary {
     last_event_time: Option<DateTime<Utc>>,
 }
 
-pub fn aws_detect(
-    rules: &PathBuf,
-    directory: &Option<PathBuf>,
-    file: &Option<PathBuf>,
-    output: &Option<PathBuf>,
-    no_color: bool,
-    no_frequency: bool,
-    no_summary: bool,
+#[derive(Debug)]
+pub enum OutputType {
+    Csv,
+    Json,
+    Jsonl,
+    CsvAndJson,
+    CsvAndJsonl,
+}
+
+impl OutputType {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(OutputType::Csv),
+            2 => Some(OutputType::Json),
+            3 => Some(OutputType::Jsonl),
+            4 => Some(OutputType::CsvAndJson),
+            5 => Some(OutputType::CsvAndJsonl),
+            _ => None,
+        }
+    }
+}
+
+fn write_record(
+    profile: &[(String, String)],
+    event: &Event,
+    rule: &Rule,
+    csv_writer: &mut Option<Writer<Box<dyn Write>>>,
+    json_writer: &mut Option<BufWriter<Box<dyn Write>>>,
+    jsonl_writer: &mut Option<BufWriter<Box<dyn Write>>>,
+    std_writer: &mut Option<Writer<Box<dyn Write>>>,
 ) {
+    let record: Vec<String> = profile
+        .iter()
+        .map(|(_k, v)| get_value_from_event(v, event, rule))
+        .collect();
+
+    // 標準出力
+    if let Some(writer) = std_writer {
+        writer.write_record(&record).unwrap();
+    }
+
+    // CSV出力
+    if let Some(writer) = csv_writer {
+        writer.write_record(&record).unwrap();
+    }
+
+    // JSON出力
+    if let Some(writer) = json_writer {
+        let mut json_record: HashMap<String, String> = HashMap::new();
+        for (k, v) in profile {
+            let value = get_value_from_event(v, event, rule);
+            json_record.insert(k.clone(), value.to_string());
+        }
+        let rec = serde_json::to_string_pretty(&json_record);
+        if let Ok(json_string) = rec {
+            writer.write_all(json_string.as_bytes()).unwrap();
+            writer.write_all(b"\n").unwrap();
+        }
+    }
+
+    // JSONL出力
+    if let Some(writer) = jsonl_writer {
+        let mut json_record: HashMap<String, String> = HashMap::new();
+        for (k, v) in profile {
+            let value = get_value_from_event(v, event, rule);
+            json_record.insert(k.clone(), value.to_string());
+        }
+        if let Ok(json_string) = serde_json::to_string(&json_record) {
+            writer.write_all(json_string.as_bytes()).unwrap();
+            writer.write_all(b"\n").unwrap();
+        }
+    }
+}
+
+pub fn aws_detect(options: &AwsCtTimelineOptions, common_opt: &CommonOptions) {
     let profile = load_profile("config/default_profile.yaml");
-    let rules = rules::load_rules_from_dir(rules);
+    let rules = rules::load_rules_from_dir(&options.rules);
     p(
         Some(Color::Rgb(0, 255, 0)),
         "Total detection rules: ",
@@ -47,9 +114,54 @@ pub fn aws_detect(
     );
     p(None, rules.len().to_string().as_str(), true);
 
-    let csv_header: Vec<&str> = profile.iter().map(|(k, _v)| k.as_str()).collect();
-    let mut wtr = get_writer(output);
-    wtr.write_record(&csv_header).unwrap();
+    let mut std_out = None;
+    let mut csv_writer = None;
+    let mut json_writer = None;
+    let mut jsonl_writer = None;
+
+    if let Some(output_path) = &options.output {
+        let output_type = OutputType::from_u8(options.output_type).unwrap_or(OutputType::Csv);
+        match output_type {
+            OutputType::Csv | OutputType::CsvAndJson | OutputType::CsvAndJsonl => {
+                let mut csv_path = output_path.clone();
+                if csv_path.extension().and_then(|ext| ext.to_str()) != Some("csv") {
+                    csv_path.set_extension("csv");
+                }
+                csv_writer = Some(get_writer(&Some(output_path.clone())));
+            }
+            _ => {}
+        }
+        match output_type {
+            OutputType::Json | OutputType::CsvAndJson => {
+                let mut json_path = output_path.clone();
+                if json_path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                    json_path.set_extension("json");
+                }
+                json_writer = Some(get_json_writer(&Some(json_path)));
+            }
+            OutputType::Jsonl | OutputType::CsvAndJsonl => {
+                let mut jsonl_path = output_path.clone();
+                if jsonl_path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                    jsonl_path.set_extension("jsonl");
+                }
+                jsonl_writer = Some(get_json_writer(&Some(jsonl_path)));
+            }
+            _ => {}
+        }
+    } else {
+        std_out = Some(get_writer(&None));
+    }
+
+    if let Some(ref mut std_out) = std_out {
+        let csv_header: Vec<&str> = profile.iter().map(|(k, _v)| k.as_str()).collect();
+        std_out.write_record(&csv_header).unwrap();
+    }
+
+    if let Some(ref mut writer) = csv_writer {
+        let csv_header: Vec<&str> = profile.iter().map(|(k, _v)| k.as_str()).collect();
+        writer.write_record(&csv_header).unwrap();
+    }
+
     let mut summary = DetectionSummary::default();
     let scan_by_all_rules = |event| {
         summary.total_events += 1;
@@ -60,11 +172,16 @@ pub fn aws_detect(
                     summary.event_with_hits += 1;
                     counted = true;
                 }
-                let record: Vec<String> = profile
-                    .iter()
-                    .map(|(_k, v)| get_value_from_event(v, &event, rule))
-                    .collect();
-                wtr.write_record(&record).unwrap();
+                write_record(
+                    &profile,
+                    &event,
+                    rule,
+                    &mut csv_writer,
+                    &mut json_writer,
+                    &mut jsonl_writer,
+                    &mut std_out,
+                );
+
                 if let Some(author) = &rule.author {
                     summary
                         .author_titles
@@ -116,21 +233,35 @@ pub fn aws_detect(
         }
     };
 
-    if let Some(d) = directory {
-        process_events_from_dir(scan_by_all_rules, d, output.is_some(), no_color).unwrap();
-    } else if let Some(f) = file {
+    if let Some(d) = &options.input_opt.directory {
+        process_events_from_dir(
+            scan_by_all_rules,
+            d,
+            options.output.is_some(),
+            common_opt.no_color,
+        )
+        .unwrap();
+    } else if let Some(f) = &options.input_opt.filepath {
         let log_contents = get_content(f);
         if let Ok(events) = load_json_from_file(&log_contents) {
             events.into_iter().for_each(scan_by_all_rules);
         }
     }
-    wtr.flush().ok();
+    if let Some(ref mut writer) = csv_writer {
+        writer.flush().unwrap();
+    }
+    if let Some(ref mut writer) = json_writer {
+        writer.flush().unwrap();
+    }
+    if let Some(ref mut writer) = jsonl_writer {
+        writer.flush().unwrap();
+    }
     println!();
     let terminal_width = match terminal_size() {
         Some((Width(w), _)) => w as usize,
         None => 100,
     };
-    if !no_frequency {
+    if !options.no_frequency {
         print_timeline_hist(&summary.timestamps, terminal_width, 3);
     }
     let table_column_num = if terminal_width <= 105 {
@@ -153,7 +284,7 @@ pub fn aws_detect(
 
     print_detected_rule_authors(&authors_count, table_column_num);
 
-    if !no_summary {
+    if !options.no_summary {
         print_summary(&summary);
     }
 }

--- a/src/aws_detect.rs
+++ b/src/aws_detect.rs
@@ -588,7 +588,11 @@ fn get_value_from_event(key: &str, event: &Event, rule: &Rule) -> String {
     if key.starts_with(".") {
         let key = key.strip_prefix(".").unwrap();
         if let Some(value) = event.get(key) {
-            s(format!("{:?}", value))
+            if key == "eventTime" {
+                s(format!("{:?}", value)).replace("T", " ").replace("Z", "")
+            } else {
+                s(format!("{:?}", value))
+            }
         } else {
             "".to_string()
         }

--- a/src/aws_detect.rs
+++ b/src/aws_detect.rs
@@ -127,7 +127,7 @@ pub fn aws_detect(options: &AwsCtTimelineOptions, common_opt: &CommonOptions) {
                 if csv_path.extension().and_then(|ext| ext.to_str()) != Some("csv") {
                     csv_path.set_extension("csv");
                 }
-                csv_writer = Some(get_writer(&Some(output_path.clone())));
+                csv_writer = Some(get_writer(&Some(csv_path)));
             }
             _ => {}
         }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -52,8 +52,12 @@ pub struct AwsCtTimelineOptions {
     pub output: Option<PathBuf>,
 
     /// Output type 1: CSV (default), 2: JSON, 3: JSONL, 4: CSV & JSON, 5: CSV & JSONL
-    #[arg(help_heading = Some("Output"), short = 't', long = "output-type", value_parser = clap::value_parser!(u8).range(1..=5), default_value = "1")]
+    #[arg(help_heading = Some("Output"), short = 't', long = "output-type", requires = "output", value_parser = clap::value_parser!(u8).range(1..=5), default_value = "1")]
     pub output_type: u8,
+
+    /// Overwrite files when saving
+    #[arg(help_heading = Some("Output"), short='C', long = "clobber", requires = "output")]
+    pub clobber: bool,
 
     /// Disable event frequency timeline (terminal needs to support Unicode)
     #[arg(help_heading = Some("Display Settings"), short = 'T', long = "no-frequency-timeline", display_order = 3)]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,8 +2,8 @@ use clap::{ArgAction, ArgGroup, Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[command(name = "Suzaku")]
-#[command(version = "0.0.1")]
+#[command(name = "suzaku")]
+#[command(version = "0.1.0")]
 #[command(author = "Yamato Security (https://github.com/Yamato-Security/suzaku - @SecurityYamato)")]
 #[command(about = "Cloud Log Threat Detection and Fast Forensics")]
 pub struct Cli {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -33,7 +33,7 @@ pub struct InputOption {
     #[arg(help_heading = Some("Input"), short = 'd', long, value_name = "DIR", conflicts_with_all = ["filepath"])]
     pub directory: Option<PathBuf>,
 
-    /// File path to one .gz/json file
+    /// File path to one gz/json file
     #[arg(help_heading = Some("Input"), short = 'f', long = "file", value_name = "FILE", conflicts_with_all = ["directory"])]
     pub filepath: Option<PathBuf>,
 }
@@ -47,7 +47,7 @@ pub struct AwsCtTimelineOptions {
     #[clap(flatten)]
     pub input_opt: InputOption,
 
-    /// Output CSV
+    /// Save the results to a file
     #[arg(help_heading = Some("Output"), short, long, value_name = "FILE")]
     pub output: Option<PathBuf>,
 
@@ -63,7 +63,7 @@ pub struct AwsCtTimelineOptions {
     #[arg(help_heading = Some("Display Settings"), short = 'T', long = "no-frequency-timeline", display_order = 3)]
     pub no_frequency: bool,
 
-    /// Do not display result Summary for faster speed
+    /// Do not display results summary
     #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 2)]
     pub no_summary: bool,
 }
@@ -71,7 +71,7 @@ pub struct AwsCtTimelineOptions {
 #[derive(Subcommand)]
 pub enum Commands {
     #[command(
-        about = "Creates a AWS CloudTrail log DFIR timeline",
+        about = "Creates an AWS CloudTrail DFIR timeline",
         disable_help_flag = true
     )]
     AwsCtTimeline {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -38,6 +38,32 @@ pub struct InputOption {
     pub filepath: Option<PathBuf>,
 }
 
+#[derive(Args, Clone, Debug, Default)]
+pub struct AwsCtTimelineOptions {
+    /// Specify a custom rule directory or file (default: ./rules)
+    #[arg(help_heading = Some("General Options"), short = 'r', long, default_value = "./rules", hide_default_value = true, value_name = "DIR/FILE")]
+    pub rules: PathBuf,
+
+    #[clap(flatten)]
+    pub input_opt: InputOption,
+
+    /// Output CSV
+    #[arg(help_heading = Some("Output"), short, long, value_name = "FILE")]
+    pub output: Option<PathBuf>,
+
+    /// Output type 1: CSV (default), 2: JSON, 3: JSONL, 4: CSV & JSON, 5: CSV & JSONL
+    #[arg(help_heading = Some("Output"), short = 't', long = "output-type", value_parser = clap::value_parser!(u8).range(1..=5), default_value = "1")]
+    pub output_type: u8,
+
+    /// Disable event frequency timeline (terminal needs to support Unicode)
+    #[arg(help_heading = Some("Display Settings"), short = 'T', long = "no-frequency-timeline", display_order = 3)]
+    pub no_frequency: bool,
+
+    /// Do not display result Summary for faster speed
+    #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 2)]
+    pub no_summary: bool,
+}
+
 #[derive(Subcommand)]
 pub enum Commands {
     #[command(
@@ -45,27 +71,11 @@ pub enum Commands {
         disable_help_flag = true
     )]
     AwsCtTimeline {
-        /// Specify a custom rule directory or file (default: ./rules)
-        #[arg(help_heading = Some("General Options"), short = 'r', long, default_value = "./rules", hide_default_value = true, value_name = "DIR/FILE")]
-        rules: PathBuf,
-
         #[clap(flatten)]
-        input_opt: InputOption,
-
-        /// Output CSV
-        #[arg(help_heading = Some("Output"), short, long, value_name = "FILE")]
-        output: Option<PathBuf>,
+        options: AwsCtTimelineOptions,
 
         #[clap(flatten)]
         common_opt: CommonOptions,
-
-        /// Disable event frequency timeline (terminal needs to support Unicode)
-        #[arg(help_heading = Some("Display Settings"), short = 'T', long = "no-frequency-timeline", display_order = 3)]
-        no_frequency: bool,
-
-        /// Do not display Results Summary for faster speed
-        #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 2)]
-        no_summary: bool,
     },
 
     #[command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,36 +32,25 @@ fn main() {
     let cmd = &Cli::parse().cmd;
     match cmd {
         AwsCtTimeline {
-            rules,
-            input_opt,
-            output,
+            options,
             common_opt,
-            no_frequency,
-            no_summary,
         } => {
             display_logo(common_opt.quiet, common_opt.no_color);
-            let dir = &input_opt.directory;
-            let file = &input_opt.filepath;
+
+            let dir = &options.input_opt.directory;
+            let file = &options.input_opt.filepath;
             if !check_path_exists(file.clone(), dir.clone()) {
                 return;
             }
-            if !rules.exists() {
+            if !options.rules.exists() {
                 p(
                     Some(Color::Red),
-                    &format!("Rule file or directory does not exist: {:?}", rules),
+                    &format!("Rule file or directory does not exist: {:?}", options.rules),
                     true,
                 );
                 return;
             }
-            aws_detect(
-                rules,
-                dir,
-                file,
-                output,
-                common_opt.no_color,
-                *no_frequency,
-                *no_summary,
-            );
+            aws_detect(options, common_opt);
         }
         AwsCtMetrics {
             input_opt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,19 @@ fn main() {
             if !check_path_exists(file.clone(), dir.clone()) {
                 return;
             }
+            if let Some(output) = &options.output {
+                if !options.clobber && output.exists() {
+                    p(
+                        None,
+                        &format!(
+                            "The file {} already exists. Please specify a different filename or add the -C, --clobber option to overwrite.",
+                            output.display()
+                        ),
+                        true,
+                    );
+                    return;
+                }
+            }
             if !options.rules.exists() {
                 p(
                     Some(Color::Red),

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -24,7 +24,7 @@ where
     F: FnMut(Event),
 {
     let (count, file_paths, total_size) = count_files_recursive(directory)?;
-    let size = ByteSize::b(total_size).to_string_as(false);
+    let size = ByteSize::b(total_size).display().to_string();
     p(Some(Color::Rgb(0, 255, 0)), "Total log files: ", false);
     p(None, count.to_string().as_str(), true);
     p(Some(Color::Rgb(0, 255, 0)), "Total file size: ", false);
@@ -51,7 +51,7 @@ where
     for path in file_paths {
         if show_progress {
             let size = fs::metadata(&path).unwrap().len();
-            let size = ByteSize::b(size).to_string_as(false);
+            let size = ByteSize::b(size).display().to_string();
             let pb_msg = format!("{} ({})", path, size);
             pb.set_message(pb_msg);
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use csv::Writer;
-use std::io::Write;
+use std::fs::File;
+use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::{fs, io};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
@@ -11,6 +12,15 @@ pub fn get_writer(output: &Option<PathBuf>) -> Writer<Box<dyn Write>> {
         Writer::from_writer(Box::new(io::stdout()))
     };
     wtr
+}
+
+pub fn get_json_writer(output: &Option<PathBuf>) -> BufWriter<Box<dyn Write>> {
+    if let Some(output) = output {
+        let file = File::create(output).expect("Failed to create file");
+        BufWriter::new(Box::new(file))
+    } else {
+        BufWriter::new(Box::new(std::io::stdout()))
+    }
 }
 
 pub fn s(input: String) -> String {


### PR DESCRIPTION
## What Changed
- Closed #11 
- Closed #33
- Closed #29 

## Evidence
```
% ./suzaku aws-ct-timeline -h
Creates a AWS CloudTrail log DFIR timeline

Usage: suzaku aws-ct-timeline [OPTIONS] <--directory <DIR>|--file <FILE>>

General Options:
  -r, --rules <DIR/FILE>  Specify a custom rule directory or file (default: ./rules)
  -h, --help              Show the help menu

Input:
  -d, --directory <DIR>  Directory of multiple gz/json files
  -f, --file <FILE>      File path to one .gz/json file

Output:
  -o, --output <FILE>              Output CSV
  -t, --output-type <OUTPUT_TYPE>  Output type 1: CSV (default), 2: JSON, 3: JSONL, 4: CSV & JSON, 5: CSV & JSONL [default: 1]
  -C, --clobber                    Overwrite files when saving

Display Settings:
  -K, --no-color               Disable color output
  -N, --no-summary             Do not display result Summary for faster speed
  -T, --no-frequency-timeline  Disable event frequency timeline (terminal needs to support Unicode)
  -q, --quiet                  Quiet mode: do not display the launch banner
```
I’d appreciate it if you could check it when you have time🙏
