### PR TITLE
feat: add min-level option

### DIFF
--- a/src/cmd/aws_detect.rs
+++ b/src/cmd/aws_detect.rs
@@ -85,7 +85,7 @@ fn write_record(
         let level_index = profile.iter().position(|(k, _)| k == "Level");
         let level = if let Some(index) = level_index {
             let org = record[index].to_lowercase();
-            let abb = abbrivate_level(&org);
+            let abb = abbreviate_level(&org);
             record[index] = abb.to_string();
             abb.to_string()
         } else {
@@ -191,7 +191,7 @@ fn write_record(
     }
 }
 
-fn abbrivate_level(level: &str) -> &str {
+fn abbreviate_level(level: &str) -> &str {
     match level {
         "critical" => "crit",
         "medium" => "med",
@@ -226,6 +226,7 @@ pub fn aws_detect(options: &AwsCtTimelineOptions, common_opt: &CommonOptions) {
         );
         return;
     }
+    let rules = rules::filter_rules_by_level(&rules, &options.min_level);
 
     p(Green.rdg(no_color), "Total detection rules: ", false);
     p(None, rules.len().to_string().as_str(), true);

--- a/src/core/rules.rs
+++ b/src/core/rules.rs
@@ -33,3 +33,72 @@ fn load_rules_recursive(directory: &PathBuf, rules: &mut Vec<Rule>) {
         }
     }
 }
+
+fn level_to_int(level: &str) -> u8 {
+    match level.to_lowercase().as_str() {
+        "info" | "informational" => 1,
+        "low" => 2,
+        "med" | "medium" => 3,
+        "high" => 4,
+        "crit" | "critical" => 5,
+        _ => 0,
+    }
+}
+
+pub fn filter_rules_by_level<'a>(rules: &'a [Rule], min_level: &'a str) -> Vec<&'a Rule> {
+    let min = level_to_int(min_level);
+    rules
+        .iter()
+        .filter(|rule| {
+            rule.level
+                .as_ref()
+                .map(|lvl| level_to_int(&format!("{:?}", lvl)) >= min)
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigma_rust::Rule;
+
+    fn make_rule_with_level(level: Option<&str>) -> Rule {
+        let yaml = format!(
+            r#"
+            title: Test Rule
+            id: test_rule
+            description: A test rule for filtering by level
+            level: {}
+            logsource:
+              product: test
+            detection:
+              selection:
+                field: value
+              condition: selection
+            "#,
+            level.unwrap_or("informational")
+        );
+        rule_from_yaml(&yaml).unwrap()
+    }
+
+    #[test]
+    fn test_filter_rules_by_level() {
+        let rules = vec![
+            make_rule_with_level(Some("informational")),
+            make_rule_with_level(Some("low")),
+            make_rule_with_level(Some("medium")),
+            make_rule_with_level(Some("high")),
+            make_rule_with_level(Some("critical")),
+        ];
+
+        let filtered = filter_rules_by_level(&rules, "informational");
+        assert_eq!(filtered.len(), 5);
+
+        let filtered = filter_rules_by_level(&rules, "medium");
+        assert_eq!(filtered.len(), 3);
+
+        let filtered = filter_rules_by_level(&rules, "critical");
+        assert_eq!(filtered.len(), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,25 @@ fn main() {
                 );
                 return;
             }
+            if options.min_level != "informational"
+                && options.min_level != "info"
+                && options.min_level != "low"
+                && options.min_level != "medium"
+                && options.min_level != "med"
+                && options.min_level != "high"
+                && options.min_level != "critical"
+                && options.min_level != "crit"
+            {
+                p(
+                    None,
+                    &format!(
+                        "Invalid minimum level: {}. Valid levels are: informational, low, medium, high, critical.",
+                        options.min_level
+                    ),
+                    true,
+                );
+                return;
+            }
             aws_detect(options, common_opt);
         }
         AwsCtMetrics {

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -92,7 +92,7 @@ pub struct AwsCtTimelineOptions {
     #[arg(help_heading = Some("Display Settings"), short = 'T', long = "no-frequency-timeline", display_order = 3)]
     pub no_frequency: bool,
 
-    /// Do not display result summary
+    /// Do not display results summary
     #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 2)]
     pub no_summary: bool,
 

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -85,7 +85,7 @@ pub struct AwsCtTimelineOptions {
     pub output_type: u8,
 
     /// Overwrite files when saving
-    #[arg(help_heading = Some("Output"), short='C', long = "clobber", requires = "output")]
+    #[arg(help_heading = Some("Output"), short='C', long = "clobber", requires = "output", display_order = 1)]
     pub clobber: bool,
 
     /// Disable event frequency timeline (terminal needs to support Unicode)
@@ -97,7 +97,7 @@ pub struct AwsCtTimelineOptions {
     pub no_summary: bool,
 
     /// Add GeoIP (ASN, city, country) info to IP addresses
-    #[arg(help_heading = Some("Output"), short = 'G', long = "GeoIP", value_name = "MAXMIND-DB-DIR")]
+    #[arg(help_heading = Some("Output"), short = 'G', long = "geo-ip", value_name = "MAXMIND-DB-DIR", display_order = 2)]
     pub geo_ip: Option<PathBuf>,
 
     /// Output the original JSON logs (only available in JSON formats)
@@ -105,7 +105,7 @@ pub struct AwsCtTimelineOptions {
     pub raw_output: bool,
 
     /// Minimum level for rules to load (default: informational)
-    #[arg(help_heading = Some("Output"), short = 'm', long = "min-level", default_value = "informational", hide_default_value = true, value_name = "LEVEL", display_order = 1)]
+    #[arg(help_heading = Some("Output"), short = 'm', long = "min-level", default_value = "informational", hide_default_value = true, value_name = "LEVEL", display_order = 3)]
     pub min_level: String,
 }
 

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -37,7 +37,6 @@ pub struct CommonOptions {
 }
 
 #[derive(Args, Clone, Debug, Default)]
-#[clap(group(ArgGroup::new("input_filtering")))]
 pub struct TimeOption {
     /// Start time of the events to load (ex: "2022-02-22T23:59:59Z)
     #[arg(help_heading = Some("Filtering"), long = "timeline-start", value_name = "DATE")]
@@ -48,7 +47,7 @@ pub struct TimeOption {
     pub timeline_end: Option<String>,
 
     /// Scan recent events based on an offset (ex: 1y, 3M, 30d, 24h, 30m)
-    #[arg(help_heading = Some("Filtering"), long = "time-offset", value_name = "OFFSET", conflicts_with = "start_timeline")]
+    #[arg(help_heading = Some("Filtering"), long = "time-offset", value_name = "OFFSET", conflicts_with = "timeline_start")]
     pub time_offset: Option<String>,
 }
 

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -92,7 +92,7 @@ pub struct AwsCtTimelineOptions {
     #[arg(help_heading = Some("Display Settings"), short = 'T', long = "no-frequency-timeline", display_order = 3)]
     pub no_frequency: bool,
 
-    /// Do not display results summary
+    /// Do not display result summary
     #[arg(help_heading = Some("Display Settings"), short = 'N', long = "no-summary", display_order = 2)]
     pub no_summary: bool,
 
@@ -103,6 +103,10 @@ pub struct AwsCtTimelineOptions {
     /// Output the original JSON logs (only available in JSON formats)
     #[arg(help_heading = Some("Output"), short = 'R', long = "raw-output")]
     pub raw_output: bool,
+
+    /// Minimum level for rules to load (default: informational)
+    #[arg(help_heading = Some("Output"), short = 'm', long = "min-level", default_value = "informational", hide_default_value = true, value_name = "LEVEL", display_order = 1)]
+    pub min_level: String,
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
## What Changed
- Closed #57 

## Evidence
```
% ./suzaku aws-ct-timeline -h
Version: 0.3.0-dev Dev Build
Yamato Security (https://github.com/Yamato-Security/suzaku - @SecurityYamato)

Usage:
  suzaku aws-ct-timeline <INPUT> [OPTIONS]

General Options:
  -r, --rules <DIR/FILE>  Specify a custom rule directory or file (default: ./rules)
  -h, --help              Show the help menu

Input:
  -d, --directory <DIR>  Directory of multiple gz/json files
  -f, --file <FILE>      File path to one gz/json file

Filtering:
      --timeline-start <DATE>  Start time of the events to load (ex: "2022-02-22T23:59:59Z)
      --timeline-end <DATE>    End time of the events to load (ex: "2020-02-22T00:00:00Z")
      --time-offset <OFFSET>   Scan recent events based on an offset (ex: 1y, 3M, 30d, 24h, 30m)

Output:
  -m, --min-level <LEVEL>          Minimum level for rules to load (default: informational)
  -o, --output <FILE>              Save the results to a file
  -t, --output-type <OUTPUT_TYPE>  Output type 1: CSV (default), 2: JSON, 3: JSONL, 4: CSV & JSON, 5: CSV & JSONL [default: 1]
  -C, --clobber                    Overwrite files when saving
  -G, --GeoIP <MAXMIND-DB-DIR>     Add GeoIP (ASN, city, country) info to IP addresses
  -R, --raw-output                 Output the original JSON logs (only available in JSON formats)

Display Settings:
  -K, --no-color               Disable color output
  -N, --no-summary             Do not display result summary
  -T, --no-frequency-timeline  Disable event frequency timeline (terminal needs to support Unicode)
  -q, --quiet                  Quiet mode: do not display the launch banner
```

