### PR TITLE
Add Terraform-based ECS setup and usage instructions for Suzaku

### DIFF
--- a/src/cmd/aws_detect.rs
+++ b/src/cmd/aws_detect.rs
@@ -106,7 +106,7 @@ pub fn write_record(
         for (i, col) in record.iter().enumerate() {
             buf.set_color(ColorSpec::new().set_fg(color.rdg(no_color)))
                 .ok();
-            write!(buf, "{}", col).ok();
+            write!(buf, "{col}").ok();
             if i != record.len() - 1 {
                 if no_color {
                     buf.set_color(ColorSpec::new().set_fg(None)).ok();
@@ -427,7 +427,7 @@ fn print_summary_levels(sum: &DetectionSummary, levels: &Vec<(&str, SuzakuColor)
             );
             p(color.rdg(false), &msg, true);
         } else {
-            let msg = format!("Total | Unique {} detections: 0 (0%) | 0 (0%)", level);
+            let msg = format!("Total | Unique {level} detections: 0 (0%) | 0 (0%)");
             p(color.rdg(false), &msg, true);
         }
     }
@@ -460,7 +460,7 @@ fn print_summary_dates_with_hits(sum: &DetectionSummary, levels: &Vec<(&str, Suz
                 p(color.rdg(false), &msg, false);
             }
         } else {
-            p(color.rdg(false), &format!("{}: n/a", level), false);
+            p(color.rdg(false), &format!("{level}: n/a"), false);
         }
         if *level != "informational" {
             p(None, ", ", false);
@@ -500,7 +500,7 @@ fn print_summary_table(sum: &DetectionSummary, levels: &Vec<(&str, SuzakuColor)>
     for chunk in table_data.chunks(2) {
         let heads = chunk
             .iter()
-            .map(|(level, (color, _))| Cell::new(format!("Top {} alerts:", level)).fg(rgb(color)))
+            .map(|(level, (color, _))| Cell::new(format!("Top {level} alerts:")).fg(rgb(color)))
             .collect::<Vec<_>>();
         let columns = chunk
             .iter()

--- a/src/cmd/aws_metrics.rs
+++ b/src/cmd/aws_metrics.rs
@@ -78,7 +78,7 @@ fn print_count_map_desc(
     for (event_name, count) in total_vec {
         let count = count.to_string();
         let rate = (count.parse::<f64>().unwrap() / total as f64) * 100.0;
-        let rate = format!("{:.2}%", rate);
+        let rate = format!("{rate:.2}%");
         let record = vec![event_name, rate.as_str(), count.as_str()];
         if output.is_none() {
             table.add_row(record.iter().map(Cell::new));
@@ -89,6 +89,6 @@ fn print_count_map_desc(
     wrt.flush().ok();
     match output {
         Some(csv) => output_path_info(no_color, [csv.clone()].as_slice()),
-        None => println!("{}", table),
+        None => println!("{table}"),
     }
 }

--- a/src/cmd/aws_summary.rs
+++ b/src/cmd/aws_summary.rs
@@ -173,7 +173,7 @@ pub fn aws_summary(
                         let asn = geo.get_asn(ip);
                         let country = geo.get_country(ip);
                         let city = geo.get_city(ip);
-                        ip_str = format!("{} ({}, {}, {})", ip_str, asn, city, country);
+                        ip_str = format!("{ip_str} ({asn}, {city}, {country})");
                     }
                 }
                 ip_str
@@ -210,25 +210,25 @@ pub fn aws_summary(
         let mut abused_api_success = "".to_string();
         if let Some(desc) = abused_aws_api_calls.get(&event_name) {
             if error_code != "AccessDenied" {
-                abused_api_success = format!("{} ({}) - {}", event_name, event_source, desc);
+                abused_api_success = format!("{event_name} ({event_source}) - {desc}");
             }
         };
 
         let mut abused_api_failed = "".to_string();
         if let Some(desc) = abused_aws_api_calls.get(&event_name) {
             if error_code == "AccessDenied" {
-                abused_api_failed = format!("{} ({}) - {}", event_name, event_source, desc);
+                abused_api_failed = format!("{event_name} ({event_source}) - {desc}");
             }
         };
 
         let mut other_api_success = "".to_string();
         if !abused_aws_api_calls.contains_key(&event_name) && error_code != "AccessDenied" {
-            other_api_success = format!("{} ({})", event_name, event_source);
+            other_api_success = format!("{event_name} ({event_source})");
         };
 
         let mut other_api_failed = "".to_string();
         if !abused_aws_api_calls.contains_key(&event_name) && error_code == "AccessDenied" {
-            other_api_failed = format!("{} ({})", event_name, event_source);
+            other_api_failed = format!("{event_name} ({event_source})");
         };
 
         let entry = user_data.entry(user_identity_arn.clone()).or_default();
@@ -337,7 +337,7 @@ fn output_summary(
     let fmt_val_total = |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
         let total: usize = map.values().map(|v| v.0).sum();
         let total = total.to_formatted_string(&Locale::en);
-        format!("| {} {}", msg, total)
+        format!("| {msg} {total}")
     };
 
     for (user_arn, summary) in sorted_user_data.iter() {
@@ -361,22 +361,22 @@ fn output_summary(
         let mut abused_suc = fmt_key_total("Unique APIs", &summary.abused_api_success);
         if let Some(pos) = abused_suc.find('\n') {
             let abused_suc_val = fmt_val_total("Total APIs", &summary.abused_api_success);
-            abused_suc.insert_str(pos, &format!(" {}", abused_suc_val));
+            abused_suc.insert_str(pos, &format!(" {abused_suc_val}"));
         }
         let mut abused_fai = fmt_key_total("Unique APIs", &summary.abused_api_failed);
         if let Some(pos) = abused_fai.find('\n') {
             let abused_fai_val = fmt_val_total("Total APIs", &summary.abused_api_failed);
-            abused_fai.insert_str(pos, &format!(" {}", abused_fai_val));
+            abused_fai.insert_str(pos, &format!(" {abused_fai_val}"));
         }
         let mut other_suc = fmt_key_total("Unique APIs", &summary.other_api_success);
         if let Some(pos) = other_suc.find('\n') {
             let other_suc_val = fmt_val_total("Total APIs", &summary.other_api_success);
-            other_suc.insert_str(pos, &format!(" {}", other_suc_val));
+            other_suc.insert_str(pos, &format!(" {other_suc_val}"));
         }
         let mut other_fai = fmt_key_total("Unique APIs", &summary.other_api_failed);
         if let Some(pos) = other_fai.find('\n') {
             let other_fai_val = fmt_val_total("Total APIs", &summary.other_api_failed);
-            other_fai.insert_str(pos, &format!(" {}", other_fai_val));
+            other_fai.insert_str(pos, &format!(" {other_fai_val}"));
         }
 
         if *hide_descriptions {

--- a/src/core/rules.rs
+++ b/src/core/rules.rs
@@ -52,7 +52,7 @@ pub fn filter_rules_by_level<'a>(rules: &'a [Rule], min_level: &'a str) -> Vec<&
         .filter(|rule| {
             rule.level
                 .as_ref()
-                .map(|lvl| level_to_int(&format!("{:?}", lvl)) >= min)
+                .map(|lvl| level_to_int(&format!("{lvl:?}")) >= min)
                 .unwrap_or(false)
         })
         .collect()

--- a/src/core/scan.rs
+++ b/src/core/scan.rs
@@ -119,7 +119,7 @@ where
         if show_progress {
             let size = fs::metadata(&path).unwrap().len();
             let size = ByteSize::b(size).display().to_string();
-            let pb_msg = format!("{} ({})", path, size);
+            let pb_msg = format!("{path} ({size})");
             pb.set_message(pb_msg);
         }
         let log_contents = if path.ends_with("json") {
@@ -261,7 +261,7 @@ fn detect_events(
                 }
 
                 if let Some(level) = &rule.level {
-                    let level = format!("{:?}", level).to_lowercase();
+                    let level = format!("{level:?}").to_lowercase();
                     summary
                         .level_with_hits
                         .entry(level)
@@ -287,7 +287,7 @@ fn detect_events(
                             summary.last_event_time = Some(event_time);
                         }
                         if let Some(level) = &rule.level {
-                            let level = format!("{:?}", level).to_lowercase();
+                            let level = format!("{level:?}").to_lowercase();
                             let date = event_time.date_naive().format("%Y-%m-%d").to_string();
                             summary
                                 .dates_with_hits

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -28,14 +28,14 @@ pub fn get_json_writer(output: &Option<PathBuf>) -> BufWriter<Box<dyn Write>> {
 pub fn check_path_exists(filepath: Option<PathBuf>, dirpath: Option<PathBuf>) -> bool {
     if let Some(file) = filepath {
         if !file.exists() {
-            println!("File {:?} does not exist.", file);
+            println!("File {file:?} does not exist.");
             return false;
         }
     }
 
     if let Some(dir) = dirpath {
         if !dir.exists() {
-            println!("Directory {:?} does not exist.", dir);
+            println!("Directory {dir:?} does not exist.");
             return false;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn main() {
     p(Green.rdg(no_color), "Elapsed time: ", false);
     p(
         None,
-        &format!("{:02}:{:02}:{:02}\n", hours, minutes, seconds),
+        &format!("{hours:02}:{minutes:02}:{seconds:02}\n"),
         true,
     );
     let debug = match cmd {
@@ -195,11 +195,11 @@ fn display_logo(quiet: bool, no_color: bool, time: bool, help: bool) {
         p(None, msg.as_str(), true);
     }
     if help {
-        let msg = format!("Version: {} ({})", VERSION, RELEASE_NAME);
+        let msg = format!("Version: {VERSION} ({RELEASE_NAME})");
         p(None, msg.as_str(), true);
     } else {
         p(Green.rdg(no_color), "Version: ", false);
-        p(None, &format!("{} ({})\n", VERSION, RELEASE_NAME), false);
+        p(None, &format!("{VERSION} ({RELEASE_NAME})\n"), false);
     }
     println!()
 }

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,1 @@
+terraform.tfvars

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,122 @@
+# Run Suzaku on AWS ECS Fargate
+
+This repository provides the Terraform configuration and execution steps to run [Suzaku](https://github.com/Yamato-Security/suzaku), a digital forensics and threat detection tool, on AWS ECS Fargate. The flow includes setting up infrastructure, running Suzaku against CloudTrail logs stored in S3, and tearing down the infrastructure afterwards.
+
+---
+
+## Prerequisites
+
+- AWS CLI configured (`aws configure`)
+- Terraform installed (`>= v1.0`)
+- An S3 bucket with CloudTrail logs uploaded
+- Permissions to create ECS resources, IAM roles, VPC, etc.
+
+---
+
+## Configuration: `terraform.tfvars`
+Before running Terraform, create a `terraform.tfvars` file in the terraform directory with the following content:
+
+```hcl
+suzaku_task_policy_resources = {
+  get_object      = "arn:aws:s3:::suzaku-input-logs/*"
+  list_bucket     = "arn:aws:s3:::suzaku-input-logs"
+  put_object      = "arn:aws:s3:::suzaku-output-logs/*"
+  cloudwatch_logs = "arn:aws:logs:*:*:log-group:/ecs/suzaku:*"
+}
+```
+
+### Explanation
+- get_object: Grants read access to CloudTrail logs stored in the specified S3 bucket.
+- list_bucket: Allows listing the contents of the input bucket.
+- put_object: Allows writing output files (e.g., reports) to another S3 location.
+- cloudwatch_logs: Grants permission to write logs to CloudWatch for debugging or monitoring purposes.
+
+Replace the S3 bucket names with your actual input/output bucket names.
+
+
+## Step-by-step Execution
+
+### 1. Initialize Terraform
+
+Initialize the Terraform working directory to download providers and modules.
+
+```bash
+terraform init
+```
+
+### 2. Plan Infrastructure Changes
+Review the execution plan to understand what will be created.
+
+```bash
+terraform plan
+```
+
+### 3. Apply Infrastructure
+Provision all the required AWS resources using Terraform.
+
+```bash
+terraform apply -auto-approve
+```
+
+This sets up:
+- ECS cluster and task definition
+- VPC, subnet, and security group
+- IAM roles and execution policies
+- Log group for CloudWatch
+
+
+### 4. Run ECS Task
+Manually start an ECS Fargate task to run suzaku.
+```bash
+aws ecs run-task \
+  --cluster suzaku-ecs-cluster \
+  --launch-type FARGATE \
+  --network-configuration 'awsvpcConfiguration={subnets=[${subnet_id}],securityGroups=[${security_group_id}],assignPublicIp="ENABLED"}' \
+  --task-definition suzaku-task \
+  --enable-execute-command
+```
+
+💡 Note: Replace ${subnet_id} and ${security_group_id} with actual values from Terraform output.
+
+### 5. Log in to the ECS Container
+Wait a few moments for the task to start, then connect to it using execute-command.
+```bash
+aws ecs execute-command \
+  --cluster suzaku-ecs-cluster \
+  --task ${task_id} \
+  --container suzaku \
+  --interactive \
+  --command "/bin/bash"
+```
+💡 Note: Replace ${task_id} with the ID returned from the run-task command.
+
+### 6. Copy CloudTrail Logs from S3
+Download CloudTrail log files from your S3 bucket to the ECS container.
+
+```bash
+mkdir /tmp/s3
+aws s3 cp ${s3_path} /tmp/s3/ --recursive
+```
+💡 Note: Replace ${s3_path} with your actual S3 path, e.g., s3://your-bucket/path/.
+
+### 7. Run Suzaku
+Execute the Suzaku CLI commands within the container.
+```bash
+suzaku update-rules
+suzaku aws-ct-metrics --directory /tmp/s3/
+```
+
+### 8. Stop the ECS Task
+After analysis, stop the running ECS task.
+```bash
+aws ecs stop-task \
+  --cluster suzaku-ecs-cluster \
+  --task ${task_id}
+```
+
+### 9. Destroy Infrastructure
+Tear down all the provisioned resources.
+```bash
+terraform destroy -auto-approve
+```
+

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,6 +16,10 @@ This repository provides the Terraform configuration and execution steps to run 
 ## Configuration: `terraform.tfvars`
 Before running Terraform, create a `terraform.tfvars` file in the terraform directory with the following content:
 
+```bash
+cp terraform.tfvars.template terraform.tfvars
+```
+
 ```hcl
 suzaku_task_policy_resources = {
   get_object      = "arn:aws:s3:::suzaku-input-logs/*"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,7 @@
 # Run Suzaku on AWS ECS Fargate
 
-This repository provides the Terraform configuration and execution steps to run [Suzaku](https://github.com/Yamato-Security/suzaku), a digital forensics and threat detection tool, on AWS ECS Fargate. The flow includes setting up infrastructure, running Suzaku against CloudTrail logs stored in S3, and tearing down the infrastructure afterwards.
+This repository provides the Terraform configuration and execution steps to run Suzaku on AWS ECS Fargate.
+The flow includes setting up the infrastructure, running Suzaku against CloudTrail logs stored in S3, and tearing down the infrastructure afterwards.
 
 ---
 
@@ -10,6 +11,7 @@ This repository provides the Terraform configuration and execution steps to run 
 - Terraform installed (`>= v1.0`)
 - An S3 bucket with CloudTrail logs uploaded
 - Permissions to create ECS resources, IAM roles, VPC, etc.
+- [SessionManagerPlugin installed](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 
 ---
 

--- a/terraform/infra.tf
+++ b/terraform/infra.tf
@@ -1,0 +1,223 @@
+# ========================================
+# suzaku ECS Fargate
+# VPC create to task run
+# ========================================
+
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+# -------------------------------
+# VPC
+# -------------------------------
+resource "aws_vpc" "suzaku_vpc" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "suzaku-vpc"
+  }
+}
+
+# Internet Gateway
+resource "aws_internet_gateway" "suzaku_igw" {
+  vpc_id = aws_vpc.suzaku_vpc.id
+  tags = {
+    Name = "suzaku-igw"
+  }
+}
+
+# Public Subnet
+resource "aws_subnet" "suzaku_public_subnet" {
+  vpc_id                  = aws_vpc.suzaku_vpc.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "suzaku-public-subnet"
+  }
+}
+
+# Route Table
+resource "aws_route_table" "suzaku_public_rt" {
+  vpc_id = aws_vpc.suzaku_vpc.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.suzaku_igw.id
+  }
+  tags = {
+    Name = "suzaku-public-rt"
+  }
+}
+
+# Route Table Association
+resource "aws_route_table_association" "suzaku_public_rt_assoc" {
+  subnet_id      = aws_subnet.suzaku_public_subnet.id
+  route_table_id = aws_route_table.suzaku_public_rt.id
+}
+
+# -------------------------------
+# Security Group
+# -------------------------------
+resource "aws_security_group" "suzaku_sg" {
+  name        = "suzaku-sg"
+  description = "Allow all outbound traffic"
+  vpc_id      = aws_vpc.suzaku_vpc.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# -------------------------------
+# IAM Role for ECS Task
+# -------------------------------
+resource "aws_iam_role" "suzaku_task_role" {
+  name = "suzaku-task-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# IAM Policy for S3 and SSM Messages
+resource "aws_iam_role_policy" "suzaku_task_policy" {
+  name = "suzaku-task-policy"
+  role = aws_iam_role.suzaku_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = ["s3:GetObject"],
+        Resource = var.suzaku_task_policy_resources["get_object"]
+      },
+      {
+        Effect = "Allow",
+        Action = ["s3:ListBucket"],
+        Resource = var.suzaku_task_policy_resources["list_bucket"]
+      },
+      {
+        Effect = "Allow",
+        Action = ["s3:PutObject"],
+        Resource = var.suzaku_task_policy_resources["put_object"]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+        ],
+        "Resource": "arn:aws:logs:*:*:log-group:/ecs/suzaku:*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# -------------------------------
+# ECS Cluster
+# -------------------------------
+resource "aws_ecs_cluster" "suzaku_cluster" {
+  name = "suzaku-ecs-cluster"
+}
+
+# -------------------------------
+# ECS Task Definition
+# -------------------------------
+resource "aws_ecs_task_definition" "suzaku_task_def" {
+  family                   = "suzaku-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "1024"   # 1 vCPU
+  memory                   = "3072"   # 3GB
+  execution_role_arn       = aws_iam_role.suzaku_task_role.arn
+  task_role_arn            = aws_iam_role.suzaku_task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "suzaku"
+      image     = "public.ecr.aws/q6q8s3z6/suzaku:latest"
+      essential = true
+      command   = ["/bin/bash", "-c", "while true; do sleep 3600; done"]
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          awslogs-group         = "/ecs/suzaku"
+          awslogs-region        = "ap-northeast-1"
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+# -------------------------------
+# ECS Service
+# -------------------------------
+resource "aws_ecs_service" "suzaku_service" {
+  name            = "suzaku-service"
+  cluster         = aws_ecs_cluster.suzaku_cluster.id
+  task_definition = aws_ecs_task_definition.suzaku_task_def.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  enable_execute_command = true
+
+  network_configuration {
+    subnets         = [aws_subnet.suzaku_public_subnet.id]
+    security_groups = [aws_security_group.suzaku_sg.id]
+    assign_public_ip = true
+  }
+  depends_on = [aws_cloudwatch_log_group.suzaku_log_group]
+}
+
+
+# CloudWatch Logs Group
+resource "aws_cloudwatch_log_group" "suzaku_log_group" {
+  name              = "/ecs/suzaku"
+  retention_in_days = 7
+}
+
+# -------------------------------
+# Output Variables
+# -------------------------------
+output "vpc_id" {
+  value = aws_vpc.suzaku_vpc.id
+}
+
+output "subnet_id" {
+  value = aws_subnet.suzaku_public_subnet.id
+}
+
+output "security_group_id" {
+  value = aws_security_group.suzaku_sg.id
+}
+
+output "ecs_cluster_name" {
+  value = aws_ecs_cluster.suzaku_cluster.name
+}
+
+output "task_definition_arn" {
+  value = aws_ecs_task_definition.suzaku_task_def.arn
+}

--- a/terraform/terraform.tfvars.template
+++ b/terraform/terraform.tfvars.template
@@ -1,0 +1,7 @@
+# terraform.tfvars.template
+suzaku_task_policy_resources = {
+  get_object      = "arn:aws:s3:::your-input-bucket-name/*"
+  list_bucket     = "arn:aws:s3:::your-input-bucket-name"
+  put_object      = "arn:aws:s3:::your-output-bucket-name/*"
+  cloudwatch_logs = "arn:aws:logs:*:*:log-group:/ecs/suzaku:*"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "suzaku_task_policy_resources" {
+  type = map(any)
+  description = "Resources used in suzaku_task_policy"
+}


### PR DESCRIPTION
### Summary

This PR adds the necessary Terraform setup and usage instructions to run suzaku on AWS ECS Fargate.

### Changes

- Added `README.md` with step-by-step instructions:
  - Terraform-based infrastructure setup
  - ECS task execution and login
  - Suzaku usage example with S3 input
  - Teardown instructions
- Added `terraform.tfvars.template` as a reference for required input variables

### Notes

- `terraform.tfvars.template` should be copied to `terraform.tfvars` and edited locally by each user.
- Push access to relevant S3 buckets and ECS permissions are assumed.
- Let me know if we should add automation for task execution in the future.
