### PR TITLE
fix: Panic when file is trying to be scanned but directory option is used

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,11 @@
 # 変更点
 
+## 1.0.1 [xxxx/xx/xx] - Black Hat Arsenal USA 2025 Release
+
+**バグ修正:**
+
+- 無効なファイルやディレクトリ入力に対するエラー処理の改善 (#99) (@fukusuket)
+
 ## 1.0.0 [2025/07/31] - Black Hat Arsenal USA 2025 Release
 
 **新機能:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 1.0.1 [xxxx/xx/xx] - Black Hat Arsenal USA 2025 Release
+
+**Bug Fixes:**
+
+- Better error handling for invalid file and directory input. (#99) (@fukusuket)
+
 ## 1.0.0 [2025/07/31] - Black Hat Arsenal USA 2025 Release
 
 **New Features:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -1319,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1416,7 +1416,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suzaku"
-version = "1.0.0"
+version = "1.0.1-dev"
 dependencies = [
  "bytesize",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "suzaku"
-version = "1.0.0"
+version = "1.0.1-dev"
 repository = "https://github.com/Yamato-Security/suzaku"
 authors = ["Yamato Security @SecurityYamato"]
 edition = "2024"

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -31,11 +31,19 @@ pub fn check_path_exists(filepath: Option<PathBuf>, dirpath: Option<PathBuf>) ->
             println!("File {file:?} does not exist.");
             return false;
         }
+        if !file.is_file() {
+            println!("File {file:?} is not a valid file.");
+            return false;
+        }
     }
 
     if let Some(dir) = dirpath {
         if !dir.exists() {
             println!("Directory {dir:?} does not exist.");
+            return false;
+        }
+        if !dir.is_dir() {
+            println!("Path {dir:?} is not a valid directory.");
             return false;
         }
     }

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -32,7 +32,7 @@ pub fn check_path_exists(filepath: Option<PathBuf>, dirpath: Option<PathBuf>) ->
             return false;
         }
         if !file.is_file() {
-            println!("File {file:?} is not a valid file.");
+            println!("Path {file:?} is not a file (it may be a directory or special file type).");
             return false;
         }
     }

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -43,7 +43,7 @@ pub fn check_path_exists(filepath: Option<PathBuf>, dirpath: Option<PathBuf>) ->
             return false;
         }
         if !dir.is_dir() {
-            println!("Path {dir:?} is not a valid directory.");
+            println!("Path {dir:?} is not a directory (it may be a file or special file type).");
             return false;
         }
     }


### PR DESCRIPTION
## What Changed

- Closed #99 
- refactor: remove duplicated logic in aws_detect_write.rs

## Evidence
```
fukusuke@fukusukenoMacBook-Air suzaku-1.0.0-mac-aarch64 % ./suzaku aws-ct-timeline -f ../data/suzaku-sample-data-main -o timeline.csv -q
Start time: 2025/08/02 13:48
Version: 1.0.0 (Black Hat Arsenal USA 2025 Release)

Path "../data/suzaku-sample-data-main" is not a file (it may be a directory or special file type).
fukusuke@fukusukenoMacBook-Air suzaku-1.0.0-mac-aarch64 % ./suzaku aws-ct-timeline -d ../data/suzaku-sample-data-main/flaws.cloud-cloudtrail-logs/flaws_cloudtrail00.json.gz -o timeline.csv -q
Start time: 2025/08/02 13:49
Version: 1.0.0 (Black Hat Arsenal USA 2025 Release)

Path "../data/suzaku-sample-data-main/flaws.cloud-cloudtrail-logs/flaws_cloudtrail00.json.gz" is not a directory (it may be a file or special file type).
fukusuke@fukusukenoMacBook-Air suzaku-1.0.0-mac-aarch64 %
```

I’d appreciate it if you could check it when you have time🙏