### PR TITLE
feat: add file date filtering options for aws command

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -11,6 +11,7 @@
 
 - 異なるログソースの取り扱いを容易にするため、コードをリファクタリングした。 (@fukusuket)
 - Microsoft Graph API JSON形式のAzureログに対応した。 (#113) (@fukusuket)
+- 既存の `--timeline-start/--timeline-end` オプション（ファイル内のイベントタイムスタンプに基づいて動作する）とは異なり、S3キーの日付プレフィックスに基づいてオブジェクトをフィルタリングする `--file-date-from/--file-date-to` オプションを追加した。 (#118) (@fukusuket)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Code refactored for easier handling of different log sources. (@fukusuket)
 - Added support for Microsoft Graph API JSON format for Azure logs. (#113) (@fukusuket)
+- Added `--file-date-from/--file-date-to` options that filter objects by their S3 key date prefix, distinct from the existing `--timeline-start/--timeline-end` options, which operates on in-file event timestamps. (#118) (@fukusuket)
 
 **Bug Fixes:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1342,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -1471,12 +1471,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1537,9 +1537,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -1567,9 +1567,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "flate2",
@@ -1578,15 +1578,15 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
  "http",
@@ -1607,10 +1607,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1675,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -1854,16 +1854,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1881,31 +1872,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1915,22 +1889,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1939,22 +1901,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1963,22 +1913,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1987,22 +1925,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/src/cmd/aws/aws_metrics.rs
+++ b/src/cmd/aws/aws_metrics.rs
@@ -41,7 +41,15 @@ pub fn aws_metrics(input_opt: &InputOption, field: &str, output: &Option<PathBuf
     };
 
     if let Some(d) = directory {
-        process_events_from_dir(stats_func, d, true, no_color, &LogSource::Aws).unwrap();
+        process_events_from_dir(
+            stats_func,
+            d,
+            true,
+            no_color,
+            &LogSource::Aws,
+            &input_opt.file_date_opt,
+        )
+        .unwrap();
         print_count_map_desc(csv_header, &count_map, wtr, output, no_color);
     } else if let Some(f) = file {
         let log_contents = get_content(f);

--- a/src/cmd/aws/aws_search.rs
+++ b/src/cmd/aws/aws_search.rs
@@ -113,6 +113,7 @@ level: informational";
             options.output_opt.output.is_some(),
             no_color,
             &LogSource::Aws,
+            &options.input_opt.file_date_opt,
         )
         .unwrap();
     } else if let Some(f) = file {

--- a/src/cmd/aws/aws_summary.rs
+++ b/src/cmd/aws/aws_summary.rs
@@ -253,7 +253,15 @@ pub fn aws_summary(
     };
     let abused_aws_api_values: Vec<String> = abused_aws_api_calls.values().cloned().collect();
     if let Some(d) = directory {
-        process_events_from_dir(summary_func, d, true, no_color, &LogSource::Aws).unwrap();
+        process_events_from_dir(
+            summary_func,
+            d,
+            true,
+            no_color,
+            &LogSource::Aws,
+            &input_opt.file_date_opt,
+        )
+        .unwrap();
         output_summary(
             &user_data,
             output,

--- a/src/core/scan.rs
+++ b/src/core/scan.rs
@@ -96,6 +96,27 @@ pub fn process_events_from_dir<F>(
 where
     F: FnMut(&[Value]),
 {
+    if file_date_opt.file_date_from.is_some() || file_date_opt.file_date_to.is_some() {
+        let from_str = file_date_opt
+            .file_date_from
+            .as_deref()
+            .map(format_date_display)
+            .unwrap_or_else(|| "*".to_string());
+        let to_str = file_date_opt
+            .file_date_to
+            .as_deref()
+            .map(format_date_display)
+            .unwrap_or_else(|| "*".to_string());
+        p(
+            Orange.rdg(no_color),
+            &format!(
+                "Filtering files by filename date prefix ({} - {}). Please wait. This may take a few minutes.",
+                from_str, to_str
+            ),
+            true,
+        );
+        println!();
+    }
     let (count, file_paths, total_size) = count_files_recursive(directory, file_date_opt)?;
     let size = ByteSize::b(total_size).display().to_string();
 
@@ -396,6 +417,15 @@ pub fn append_summary_data(
                     .or_insert(1);
             }
         }
+    }
+}
+
+/// Convert YYYYMMDD string to YYYY-MM-DD for display.
+fn format_date_display(s: &str) -> String {
+    if s.len() == 8 {
+        format!("{}-{}-{}", &s[0..4], &s[4..6], &s[6..8])
+    } else {
+        s.to_string()
     }
 }
 

--- a/src/core/scan.rs
+++ b/src/core/scan.rs
@@ -3,8 +3,8 @@ use crate::core::log_source::{LogSource, is_match_service};
 use crate::core::summary::DetectionSummary;
 use crate::core::timeline_writer::{OutputContext, write_record};
 use crate::core::util::p;
-use crate::option::cli::{TimeOption, TimelineOptions};
-use crate::option::timefiler::filter_by_time;
+use crate::option::cli::{FileDateOption, TimeOption, TimelineOptions};
+use crate::option::timefiler::{filter_by_time, filter_file_by_date_path};
 use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
@@ -80,6 +80,7 @@ pub fn scan_directory<'a>(
         options.output_opt.output.is_some(),
         no_color,
         log,
+        &options.input_opt.file_date_opt,
     )
     .unwrap();
 }
@@ -90,11 +91,12 @@ pub fn process_events_from_dir<F>(
     show_progress: bool,
     no_color: bool,
     log: &LogSource,
+    file_date_opt: &FileDateOption,
 ) -> Result<(), Box<dyn Error>>
 where
     F: FnMut(&[Value]),
 {
-    let (count, file_paths, total_size) = count_files_recursive(directory)?;
+    let (count, file_paths, total_size) = count_files_recursive(directory, file_date_opt)?;
     let size = ByteSize::b(total_size).display().to_string();
 
     p(Green.rdg(no_color), "Total log files: ", false);
@@ -397,7 +399,10 @@ pub fn append_summary_data(
     }
 }
 
-fn count_files_recursive(directory: &PathBuf) -> Result<(usize, Vec<String>, u64), Box<dyn Error>> {
+fn count_files_recursive(
+    directory: &PathBuf,
+    file_date_opt: &FileDateOption,
+) -> Result<(usize, Vec<String>, u64), Box<dyn Error>> {
     let mut count = 0;
     let mut paths = Vec::new();
     let mut total_size = 0;
@@ -408,12 +413,16 @@ fn count_files_recursive(directory: &PathBuf) -> Result<(usize, Vec<String>, u64
             if let Some(ext) = path.extension().and_then(|s| s.to_str())
                 && (ext == "json" || ext == "gz")
             {
+                let path_str = path.to_str().unwrap();
+                if !filter_file_by_date_path(file_date_opt, path_str) {
+                    continue;
+                }
                 count += 1;
                 total_size += fs::metadata(&path)?.len();
-                paths.push(path.to_str().unwrap().to_string());
+                paths.push(path_str.to_string());
             }
         } else if path.is_dir() {
-            let (sub_count, sub_paths, sub_size) = count_files_recursive(&path)?;
+            let (sub_count, sub_paths, sub_size) = count_files_recursive(&path, file_date_opt)?;
             count += sub_count;
             total_size += sub_size;
             paths.extend(sub_paths);

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDate;
 use clap::{ArgAction, ArgGroup, Args, Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -6,6 +7,22 @@ use const_format::concatcp;
 pub const RELEASE_NAME: &str = "Dev Build";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const FULL_VERSION: &str = concatcp!(VERSION, " ", RELEASE_NAME);
+
+/// Validate that the input is a valid date in YYYYMMDD format.
+fn parse_file_date(s: &str) -> Result<String, String> {
+    if s.len() != 8 || !s.chars().all(|c| c.is_ascii_digit()) {
+        return Err(format!(
+            "'{}' is not in YYYYMMDD format (e.g. 20240115)",
+            s
+        ));
+    }
+    let year: i32 = s[0..4].parse().unwrap();
+    let month: u32 = s[4..6].parse().unwrap();
+    let day: u32 = s[6..8].parse().unwrap();
+    NaiveDate::from_ymd_opt(year, month, day)
+        .ok_or_else(|| format!("'{}' is not a valid date", s))?;
+    Ok(s.to_string())
+}
 
 #[derive(Parser)]
 #[command(name = "suzaku")]
@@ -49,6 +66,17 @@ pub struct TimeOption {
     /// Scan recent events based on an offset (ex: 1y, 3M, 30d, 24h, 30m)
     #[arg(help_heading = Some("Filtering"), long = "time-offset", value_name = "OFFSET", conflicts_with = "timeline_start", display_order = 212)]
     pub time_offset: Option<String>,
+}
+
+#[derive(Args, Clone, Debug, Default)]
+pub struct FileDateOption {
+    /// Filter files by start date based on AWSLogs S3 path date structure (ex: "20240101")
+    #[arg(help_heading = Some("Filtering"), long = "file-date-from", value_name = "DATE", value_parser = parse_file_date, display_order = 213)]
+    pub file_date_from: Option<String>,
+
+    /// Filter files by end date based on AWSLogs S3 path date structure (ex: "20241231")
+    #[arg(help_heading = Some("Filtering"), long = "file-date-to", value_name = "DATE", value_parser = parse_file_date, display_order = 214)]
+    pub file_date_to: Option<String>,
 }
 
 #[derive(Args, Clone, Debug, Default)]
@@ -116,6 +144,9 @@ pub struct InputOption {
 
     #[clap(flatten)]
     pub time_opt: TimeOption,
+
+    #[clap(flatten)]
+    pub file_date_opt: FileDateOption,
 }
 
 #[derive(Args, Clone, Debug, Default)]

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -11,10 +11,7 @@ pub const FULL_VERSION: &str = concatcp!(VERSION, " ", RELEASE_NAME);
 /// Validate that the input is a valid date in YYYYMMDD format.
 fn parse_file_date(s: &str) -> Result<String, String> {
     if s.len() != 8 || !s.chars().all(|c| c.is_ascii_digit()) {
-        return Err(format!(
-            "'{}' is not in YYYYMMDD format (e.g. 20240115)",
-            s
-        ));
+        return Err(format!("'{}' is not in YYYYMMDD format (e.g. 20240115)", s));
     }
     let year: i32 = s[0..4].parse().unwrap();
     let month: u32 = s[4..6].parse().unwrap();

--- a/src/option/timefiler.rs
+++ b/src/option/timefiler.rs
@@ -1,5 +1,6 @@
-use crate::option::cli::TimeOption;
+use crate::option::cli::{FileDateOption, TimeOption};
 use chrono::{DateTime, Duration, Utc};
+use regex::Regex;
 use serde_json::Value;
 
 pub fn filter_by_time(opt: &TimeOption, value: &Value, ts_key: &str) -> bool {
@@ -59,6 +60,33 @@ pub fn filter_by_time(opt: &TimeOption, value: &Value, ts_key: &str) -> bool {
     }
     true
 }
+/// Filter files by their path date structure (YYYY/MM/DD).
+/// Intended for AWSLogs S3-compatible paths like `AWSLogs/{account}/{service}/{region}/YYYY/MM/DD/`.
+/// If no date pattern is found in the path (e.g. Azure logs), the file is passed through (returns true).
+pub fn filter_file_by_date_path(opt: &FileDateOption, path: &str) -> bool {
+    if opt.file_date_from.is_none() && opt.file_date_to.is_none() {
+        return true;
+    }
+    let re = Regex::new(r"/(\d{4})/(\d{2})/(\d{2})/").unwrap();
+    let Some(caps) = re.captures(path) else {
+        // No YYYY/MM/DD pattern found; pass through (e.g. Azure paths)
+        return true;
+    };
+    // Compose as YYYYMMDD for direct lexicographic comparison with user input
+    let file_date = format!("{}{}{}", &caps[1], &caps[2], &caps[3]);
+    if let Some(from) = &opt.file_date_from
+        && file_date < *from
+    {
+        return false;
+    }
+    if let Some(to) = &opt.file_date_to
+        && file_date > *to
+    {
+        return false;
+    }
+    true
+}
+
 fn parse_offset(offset: &str) -> Option<Duration> {
     let (num, unit) = offset.trim().split_at(offset.len() - 1);
     let n: i64 = num.parse().ok()?;
@@ -75,7 +103,94 @@ fn parse_offset(offset: &str) -> Option<Duration> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::option::cli::FileDateOption;
     use serde_json::json;
+
+    // --- filter_file_by_date_path tests ---
+
+    #[test]
+    fn test_filter_file_no_option_passes_through() {
+        let opt = FileDateOption::default();
+        assert!(filter_file_by_date_path(
+            &opt,
+            "AWSLogs/123/CloudTrail/us-east-1/2024/01/15/xxx.json.gz"
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_within_range() {
+        let opt = FileDateOption {
+            file_date_from: Some("20240101".to_string()),
+            file_date_to: Some("20240131".to_string()),
+        };
+        assert!(filter_file_by_date_path(
+            &opt,
+            "AWSLogs/123/CloudTrail/ap-northeast-1/2024/01/15/xxx.json.gz"
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_before_range() {
+        let opt = FileDateOption {
+            file_date_from: Some("20240201".to_string()),
+            file_date_to: None,
+        };
+        assert!(!filter_file_by_date_path(
+            &opt,
+            "AWSLogs/123/CloudTrail/ap-northeast-1/2024/01/15/xxx.json.gz"
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_after_range() {
+        let opt = FileDateOption {
+            file_date_from: None,
+            file_date_to: Some("20240110".to_string()),
+        };
+        assert!(!filter_file_by_date_path(
+            &opt,
+            "AWSLogs/123/CloudTrail/ap-northeast-1/2024/01/15/xxx.json.gz"
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_on_boundary_from() {
+        let opt = FileDateOption {
+            file_date_from: Some("20240115".to_string()),
+            file_date_to: None,
+        };
+        assert!(filter_file_by_date_path(
+            &opt,
+            "AWSLogs/123/CloudTrail/ap-northeast-1/2024/01/15/xxx.json.gz"
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_on_boundary_to() {
+        let opt = FileDateOption {
+            file_date_from: None,
+            file_date_to: Some("20240115".to_string()),
+        };
+        assert!(filter_file_by_date_path(
+            &opt,
+            "AWSLogs/123/CloudTrail/ap-northeast-1/2024/01/15/xxx.json.gz"
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_no_date_pattern_passes_through() {
+        // Azure-style path without YYYY/MM/DD structure passes through
+        let opt = FileDateOption {
+            file_date_from: Some("20240101".to_string()),
+            file_date_to: Some("20241231".to_string()),
+        };
+        assert!(filter_file_by_date_path(
+            &opt,
+            "/logs/azure/auditlogs_2024_01_15.json"
+        ));
+    }
+
+    // --- filter_by_time tests ---
 
     #[test]
     fn test_filter_by_time_within_range() {

--- a/src/option/timefiler.rs
+++ b/src/option/timefiler.rs
@@ -75,12 +75,12 @@ pub fn filter_file_by_date_path(opt: &FileDateOption, path: &str) -> bool {
     // Compose as YYYYMMDD for direct lexicographic comparison with user input
     let file_date = format!("{}{}{}", &caps[1], &caps[2], &caps[3]);
     if let Some(from) = &opt.file_date_from
-        && file_date < *from
+        && file_date.as_str() < from.as_str()
     {
         return false;
     }
     if let Some(to) = &opt.file_date_to
-        && file_date > *to
+        && file_date.as_str() > to.as_str()
     {
         return false;
     }

--- a/src/option/timefiler.rs
+++ b/src/option/timefiler.rs
@@ -2,6 +2,12 @@ use crate::option::cli::{FileDateOption, TimeOption};
 use chrono::{DateTime, Duration, Utc};
 use regex::Regex;
 use serde_json::Value;
+use std::sync::LazyLock;
+
+static DATE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"[/\\](\d{4})[/\\](\d{2})[/\\](\d{2})[/\\]")
+        .expect("DATE_PATH_RE regex pattern is invalid")
+});
 
 pub fn filter_by_time(opt: &TimeOption, value: &Value, ts_key: &str) -> bool {
     let keys: Vec<&str> = ts_key
@@ -67,8 +73,7 @@ pub fn filter_file_by_date_path(opt: &FileDateOption, path: &str) -> bool {
     if opt.file_date_from.is_none() && opt.file_date_to.is_none() {
         return true;
     }
-    let re = Regex::new(r"/(\d{4})/(\d{2})/(\d{2})/").unwrap();
-    let Some(caps) = re.captures(path) else {
+    let Some(caps) = DATE_PATH_RE.captures(path) else {
         // No YYYY/MM/DD pattern found; pass through (e.g. Azure paths)
         return true;
     };
@@ -187,6 +192,19 @@ mod tests {
         assert!(filter_file_by_date_path(
             &opt,
             "/logs/azure/auditlogs_2024_01_15.json"
+        ));
+    }
+
+    #[test]
+    fn test_filter_file_windows_path_separators() {
+        // Windows-style path with backslash separators should match correctly
+        let opt = FileDateOption {
+            file_date_from: Some("20240101".to_string()),
+            file_date_to: Some("20240131".to_string()),
+        };
+        assert!(filter_file_by_date_path(
+            &opt,
+            r"AWSLogs\123\CloudTrail\us-east-1\2024\01\15\xxx.json.gz"
         ));
     }
 


### PR DESCRIPTION
## What Changed
- Closed #118 
- Added `--file-date-from` and `--file-date-to` CLI options to filter log files by the `YYYY/MM/DD` date segment in their path (AWSLogs S3-compatible paths)
- Added `filter_file_by_date_path` function applied during directory traversal to skip files outside the specified date range

## Evidence
### Integration-Test
- https://github.com/Yamato-Security/suzaku/actions/runs/23678470568

I’d appreciate it if you could check it when you have time🙏