### PR TITLE
feat: add `-output-type` option for aws-ct-summary

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -12,6 +12,7 @@
 - 異なるログソースの取り扱いを容易にするため、コードをリファクタリングした。 (@fukusuket)
 - Microsoft Graph API JSON形式のAzureログに対応した。 (#113) (@fukusuket)
 - 既存の `--timeline-start/--timeline-end` オプション（ファイル内のイベントタイムスタンプに基づいて動作する）とは異なり、S3キーの日付プレフィックスに基づいてオブジェクトをフィルタリングする `--file-date-from/--file-date-to` オプションを追加した。 (#118) (@fukusuket)
+- `aws-ct-summary`コマンドに、JSON形式で出力するための`-output-type`オプションを追加した。 (#123) (@fukusuket)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Code refactored for easier handling of different log sources. (@fukusuket)
 - Added support for Microsoft Graph API JSON format for Azure logs. (#113) (@fukusuket)
 - Added `--file-date-from/--file-date-to` options that filter objects by their S3 key date prefix, distinct from the existing `--timeline-start/--timeline-end` options, which operates on in-file event timestamps. (#118) (@fukusuket)
+- Added `-output-type` option for the `aws-ct-summary` command to output in JSON. (#123) (@fukusuket)
 
 **Bug Fixes:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "openssl",
  "rayon",
  "regex",
+ "serde",
  "serde_json",
  "sigma-rust",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -108,9 +108,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -132,9 +132,9 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -264,11 +264,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -373,17 +374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -422,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -471,12 +461,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "percent-encoding",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -517,17 +522,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -541,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -597,121 +599,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -768,13 +668,30 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "leb128fmt"
@@ -784,47 +701,30 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
 dependencies = [
  "cc",
  "cty",
- "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -839,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -854,12 +754,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litrs"
@@ -884,9 +778,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maxminddb"
-version = "0.27.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192"
+checksum = "faf6467428ad055b71e588bcedcbaf2ff605b3251deb0c52be4a04b674c546dd"
 dependencies = [
  "ipnetwork",
  "log",
@@ -903,9 +797,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -972,15 +866,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -997,25 +890,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -1054,25 +941,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
+name = "pin-project-lite"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "prettyplease"
@@ -1116,9 +1000,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1201,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -1216,18 +1100,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1254,9 +1138,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1290,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1347,16 +1231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1407,7 +1291,7 @@ dependencies = [
  "csv",
  "flate2",
  "git2",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indicatif",
  "itertools",
  "libmimalloc-sys",
@@ -1435,17 +1319,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1521,16 +1394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,28 +1459,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1645,11 +1490,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1658,14 +1503,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1676,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1686,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1699,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -1752,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1941,6 +1786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,93 +1871,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zlib-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ maxminddb = "*"
 mimalloc = { version = "*", default-features = false }
 num-format = "0.4.*"
 regex = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 termcolor = "*"
 terminal_size = "0.4.*"

--- a/src/cmd/aws/aws_summary.rs
+++ b/src/cmd/aws/aws_summary.rs
@@ -438,25 +438,43 @@ fn output_summary(
     let output_json = matches!(output_type, 2 | 4);
     let output_jsonl = matches!(output_type, 3 | 5);
 
+    let csv_path = output_csv.then(|| {
+        let mut path = output.to_path_buf();
+        path.set_extension("csv");
+        path
+    });
+    let json_path = output_json.then(|| {
+        let mut path = output.to_path_buf();
+        path.set_extension("json");
+        path
+    });
+    let jsonl_path = output_jsonl.then(|| {
+        let mut path = output.to_path_buf();
+        path.set_extension("jsonl");
+        path
+    });
+
+    if !clobber
+        && let Some(path) = [csv_path.as_ref(), json_path.as_ref(), jsonl_path.as_ref()]
+            .into_iter()
+            .flatten()
+            .find(|path| path.exists())
+    {
+        p(
+            Some(Color::Rgb(255, 0, 0)),
+            &format!(
+                "The file {} already exists. Use --clobber to overwrite.",
+                path.display()
+            ),
+            true,
+        );
+        return;
+    }
+
     let mut output_paths: Vec<PathBuf> = Vec::new();
 
     // --- CSV 出力 ---
-    if output_csv {
-        let mut csv_path = output.to_path_buf();
-        csv_path.set_extension("csv");
-
-        if !clobber && csv_path.exists() {
-            p(
-                Some(Color::Rgb(255, 0, 0)),
-                &format!(
-                    "The file {} already exists. Use --clobber to overwrite.",
-                    csv_path.display()
-                ),
-                true,
-            );
-            return;
-        }
-
+    if let Some(csv_path) = csv_path {
         let fmt_key_total = |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
             let total: usize = map.keys().len();
             let total = total.to_formatted_string(&Locale::en);
@@ -571,22 +589,7 @@ fn output_summary(
     }
 
     // --- JSON 出力 ---
-    if output_json {
-        let mut json_path = output.to_path_buf();
-        json_path.set_extension("json");
-
-        if !clobber && json_path.exists() {
-            p(
-                Some(Color::Rgb(255, 0, 0)),
-                &format!(
-                    "The file {} already exists. Use --clobber to overwrite.",
-                    json_path.display()
-                ),
-                true,
-            );
-            return;
-        }
-
+    if let Some(json_path) = json_path {
         let records = build_json_records(user_data, *hide_descriptions);
         let file = File::create(&json_path).unwrap();
         let mut writer = BufWriter::new(file);
@@ -596,22 +599,7 @@ fn output_summary(
     }
 
     // --- JSONL 出力 ---
-    if output_jsonl {
-        let mut jsonl_path = output.to_path_buf();
-        jsonl_path.set_extension("jsonl");
-
-        if !clobber && jsonl_path.exists() {
-            p(
-                Some(Color::Rgb(255, 0, 0)),
-                &format!(
-                    "The file {} already exists. Use --clobber to overwrite.",
-                    jsonl_path.display()
-                ),
-                true,
-            );
-            return;
-        }
-
+    if let Some(jsonl_path) = jsonl_path {
         let records = build_json_records(user_data, *hide_descriptions);
         let file = File::create(&jsonl_path).unwrap();
         let mut writer = BufWriter::new(file);
@@ -1071,6 +1059,24 @@ mod tests {
         // 上書きされていないこと
         let content = std::fs::read_to_string(&json_path).unwrap();
         assert_eq!(content, "original");
+    }
+
+    #[test]
+    fn test_clobber_false_preflights_all_output_paths_for_type_4() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+        let csv_path = tmp.path().join("result.csv");
+        let json_path = tmp.path().join("result.json");
+
+        std::fs::write(&json_path, "original").unwrap();
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 4, false);
+
+        assert_eq!(std::fs::read_to_string(&json_path).unwrap(), "original");
+        assert!(!csv_path.exists());
     }
 
     #[test]

--- a/src/cmd/aws/aws_summary.rs
+++ b/src/cmd/aws/aws_summary.rs
@@ -216,14 +216,8 @@ fn build_json_records(
         .map(|(arn, summary)| SummaryJsonRecord {
             user_arn: arn.clone(),
             num_of_events: summary.num_of_events,
-            first_timestamp: summary
-                .first_timestamp
-                .replace('T', " ")
-                .replace('Z', ""),
-            last_timestamp: summary
-                .last_timestamp
-                .replace('T', " ")
-                .replace('Z', ""),
+            first_timestamp: summary.first_timestamp.replace('T', " ").replace('Z', ""),
+            last_timestamp: summary.last_timestamp.replace('T', " ").replace('Z', ""),
             abused_apis_success: map_to_api_entries(&summary.abused_api_success, hide_descriptions),
             abused_apis_failed: map_to_api_entries(&summary.abused_api_failed, hide_descriptions),
             other_apis_success: map_to_api_entries(&summary.other_api_success, false),
@@ -463,33 +457,27 @@ fn output_summary(
             return;
         }
 
-        let fmt_key_total =
-            |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
-                let total: usize = map.keys().len();
-                let total = total.to_formatted_string(&Locale::en);
-                let mut result = vec![format!("{}: {}", msg, total)];
-                result.extend(
-                    map.iter()
-                        .sorted_by(|a, b| b.1.cmp(a.1))
-                        .map(|(k, v)| {
-                            format!(
-                                "{} - {} ({} ~ {})",
-                                v.0.to_formatted_string(&Locale::en),
-                                k,
-                                v.1.replace('Z', "").replace('T', " "),
-                                v.2.replace('Z', "").replace('T', " ")
-                            )
-                        }),
-                );
-                result.join("\n")
-            };
+        let fmt_key_total = |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
+            let total: usize = map.keys().len();
+            let total = total.to_formatted_string(&Locale::en);
+            let mut result = vec![format!("{}: {}", msg, total)];
+            result.extend(map.iter().sorted_by(|a, b| b.1.cmp(a.1)).map(|(k, v)| {
+                format!(
+                    "{} - {} ({} ~ {})",
+                    v.0.to_formatted_string(&Locale::en),
+                    k,
+                    v.1.replace('Z', "").replace('T', " "),
+                    v.2.replace('Z', "").replace('T', " ")
+                )
+            }));
+            result.join("\n")
+        };
 
-        let fmt_val_total =
-            |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
-                let total: usize = map.values().map(|v| v.0).sum();
-                let total = total.to_formatted_string(&Locale::en);
-                format!("| {msg} {total}")
-            };
+        let fmt_val_total = |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
+            let total: usize = map.values().map(|v| v.0).sum();
+            let total = total.to_formatted_string(&Locale::en);
+            format!("| {msg} {total}")
+        };
 
         let mut csv_wtr = get_writer(&Some(csv_path.clone()));
         let csv_header = vec![
@@ -765,7 +753,11 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "ListBuckets (s3.amazonaws.com) - List all S3 buckets".to_string(),
-            (3usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-02T00:00:00Z".to_string()),
+            (
+                3usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-02T00:00:00Z".to_string(),
+            ),
         );
         let entries = map_to_api_entries(&map, false);
         assert_eq!(entries.len(), 1);
@@ -781,7 +773,11 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "ListBuckets (s3.amazonaws.com) - List all S3 buckets".to_string(),
-            (1usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+            (
+                1usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+            ),
         );
         let entries = map_to_api_entries(&map, true);
         assert_eq!(entries[0].api, "ListBuckets (s3.amazonaws.com)");
@@ -793,7 +789,11 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "GetObject (s3.amazonaws.com)".to_string(),
-            (2usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+            (
+                2usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+            ),
         );
         let entries = map_to_api_entries(&map, false);
         assert_eq!(entries[0].api, "GetObject (s3.amazonaws.com)");
@@ -805,15 +805,27 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "ApiA (src)".to_string(),
-            (1usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+            (
+                1usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+            ),
         );
         map.insert(
             "ApiB (src)".to_string(),
-            (5usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+            (
+                5usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+            ),
         );
         map.insert(
             "ApiC (src)".to_string(),
-            (3usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+            (
+                3usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+            ),
         );
         let entries = map_to_api_entries(&map, false);
         assert_eq!(entries[0].count, 5);
@@ -830,7 +842,11 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "us-east-1".to_string(),
-            (10usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-02T00:00:00Z".to_string()),
+            (
+                10usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-02T00:00:00Z".to_string(),
+            ),
         );
         let entries = map_to_count_entries(&map);
         assert_eq!(entries.len(), 1);
@@ -845,11 +861,19 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "us-east-1".to_string(),
-            (2usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+            (
+                2usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+            ),
         );
         map.insert(
             "eu-west-1".to_string(),
-            (8usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+            (
+                8usize,
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string(),
+            ),
         );
         let entries = map_to_count_entries(&map);
         assert_eq!(entries[0].value, "eu-west-1");
@@ -863,7 +887,10 @@ mod tests {
     #[test]
     fn test_build_json_records_basic() {
         let mut user_data = HashMap::new();
-        user_data.insert("arn:aws:iam::123:user/alice".to_string(), make_test_summary());
+        user_data.insert(
+            "arn:aws:iam::123:user/alice".to_string(),
+            make_test_summary(),
+        );
 
         let records = build_json_records(&user_data, false);
 
@@ -891,7 +918,7 @@ mod tests {
         let records = build_json_records(&user_data, false);
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].num_of_events, 20); // bob が先
-        assert_eq!(records[1].num_of_events, 5);  // alice が後
+        assert_eq!(records[1].num_of_events, 5); // alice が後
     }
 
     #[test]
@@ -989,7 +1016,10 @@ mod tests {
         let output_path = tmp.path().join("result");
 
         let mut user_data = HashMap::new();
-        user_data.insert("arn:aws:iam::123:user/alice".to_string(), make_test_summary());
+        user_data.insert(
+            "arn:aws:iam::123:user/alice".to_string(),
+            make_test_summary(),
+        );
 
         output_summary(&user_data, &output_path, true, &false, vec![], 2, false);
 
@@ -1056,4 +1086,3 @@ mod tests {
         assert_ne!(content, "original");
     }
 }
-

--- a/src/cmd/aws/aws_summary.rs
+++ b/src/cmd/aws/aws_summary.rs
@@ -907,10 +907,14 @@ mod tests {
     #[test]
     fn test_build_json_records_sorted_by_events_desc() {
         let mut user_data = HashMap::new();
-        let mut summary_alice = CTSummary::default();
-        summary_alice.num_of_events = 5;
-        let mut summary_bob = CTSummary::default();
-        summary_bob.num_of_events = 20;
+        let summary_alice = CTSummary {
+            num_of_events: 5,
+            ..Default::default()
+        };
+        let summary_bob = CTSummary {
+            num_of_events: 20,
+            ..Default::default()
+        };
 
         user_data.insert("arn:aws:iam::123:user/alice".to_string(), summary_alice);
         user_data.insert("arn:aws:iam::123:user/bob".to_string(), summary_bob);

--- a/src/cmd/aws/aws_summary.rs
+++ b/src/cmd/aws/aws_summary.rs
@@ -8,13 +8,56 @@ use crate::option::timefiler::filter_by_time;
 use csv::ReaderBuilder;
 use itertools::Itertools;
 use num_format::{Locale, ToFormattedString};
+use serde::Serialize;
 use serde_json::Value;
 use sigma_rust::{Event, event_from_json};
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use termcolor::Color;
+
+// ---------------------------------------------------------------------------
+// JSON 出力用データ構造
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct ApiEntry {
+    pub api: String,
+    pub description: String,
+    pub count: usize,
+    pub first_seen: String,
+    pub last_seen: String,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+pub struct CountEntry {
+    pub value: String,
+    pub count: usize,
+    pub first_seen: String,
+    pub last_seen: String,
+}
+
+#[derive(Serialize, Debug)]
+pub struct SummaryJsonRecord {
+    pub user_arn: String,
+    pub num_of_events: usize,
+    pub first_timestamp: String,
+    pub last_timestamp: String,
+    pub abused_apis_success: Vec<ApiEntry>,
+    pub abused_apis_failed: Vec<ApiEntry>,
+    pub other_apis_success: Vec<ApiEntry>,
+    pub other_apis_failed: Vec<ApiEntry>,
+    pub aws_regions: Vec<CountEntry>,
+    pub src_ips: Vec<CountEntry>,
+    pub user_types: String,
+    pub user_access_key_ids: Vec<CountEntry>,
+    pub user_agents: Vec<CountEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// 集計用内部構造体
+// ---------------------------------------------------------------------------
 
 #[derive(Default)]
 struct CTSummary {
@@ -115,6 +158,93 @@ impl CTSummary {
     }
 }
 
+// ---------------------------------------------------------------------------
+// JSON ビルド用ヘルパー関数
+// ---------------------------------------------------------------------------
+
+/// `"EventName (source) - Description"` または `"EventName (source)"` 形式のキーを
+/// `ApiEntry` に変換して件数降順で返す。
+fn map_to_api_entries(
+    map: &HashMap<String, (usize, String, String)>,
+    hide_descriptions: bool,
+) -> Vec<ApiEntry> {
+    map.iter()
+        .sorted_by(|a, b| b.1.0.cmp(&a.1.0))
+        .map(|(key, (count, first, last))| {
+            let (api, description) = if let Some(pos) = key.find(" - ") {
+                let api = key[..pos].to_string();
+                let desc = if hide_descriptions {
+                    "".to_string()
+                } else {
+                    key[pos + 3..].to_string()
+                };
+                (api, desc)
+            } else {
+                (key.clone(), "".to_string())
+            };
+            ApiEntry {
+                api,
+                description,
+                count: *count,
+                first_seen: first.replace('T', " ").replace('Z', ""),
+                last_seen: last.replace('T', " ").replace('Z', ""),
+            }
+        })
+        .collect()
+}
+
+/// `HashMap<String, (usize, String, String)>` を件数降順の `CountEntry` リストに変換する。
+fn map_to_count_entries(map: &HashMap<String, (usize, String, String)>) -> Vec<CountEntry> {
+    map.iter()
+        .sorted_by(|a, b| b.1.0.cmp(&a.1.0))
+        .map(|(key, (count, first, last))| CountEntry {
+            value: key.clone(),
+            count: *count,
+            first_seen: first.replace('T', " ").replace('Z', ""),
+            last_seen: last.replace('T', " ").replace('Z', ""),
+        })
+        .collect()
+}
+
+/// `user_data` を JSON レコードのリスト（件数降順）に変換する。
+fn build_json_records(
+    user_data: &HashMap<String, CTSummary>,
+    hide_descriptions: bool,
+) -> Vec<SummaryJsonRecord> {
+    let mut records: Vec<SummaryJsonRecord> = user_data
+        .iter()
+        .map(|(arn, summary)| SummaryJsonRecord {
+            user_arn: arn.clone(),
+            num_of_events: summary.num_of_events,
+            first_timestamp: summary
+                .first_timestamp
+                .replace('T', " ")
+                .replace('Z', ""),
+            last_timestamp: summary
+                .last_timestamp
+                .replace('T', " ")
+                .replace('Z', ""),
+            abused_apis_success: map_to_api_entries(&summary.abused_api_success, hide_descriptions),
+            abused_apis_failed: map_to_api_entries(&summary.abused_api_failed, hide_descriptions),
+            other_apis_success: map_to_api_entries(&summary.other_api_success, false),
+            other_apis_failed: map_to_api_entries(&summary.other_api_failed, false),
+            aws_regions: map_to_count_entries(&summary.aws_regions),
+            src_ips: map_to_count_entries(&summary.src_ips),
+            user_types: summary.user_types.clone(),
+            user_access_key_ids: map_to_count_entries(&summary.access_key_ids),
+            user_agents: map_to_count_entries(&summary.user_agents),
+        })
+        .collect();
+
+    records.sort_by_key(|r| std::cmp::Reverse(r.num_of_events));
+    records
+}
+
+// ---------------------------------------------------------------------------
+// パブリックエントリポイント
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
 pub fn aws_summary(
     input_opt: &InputOption,
     output: &Path,
@@ -122,6 +252,8 @@ pub fn aws_summary(
     include_sts: &bool,
     hide_descriptions: &bool,
     geo_ip: &Option<PathBuf>,
+    output_type: u8,
+    clobber: bool,
 ) {
     let directory = &input_opt.directory;
     let file = &input_opt.filepath;
@@ -268,6 +400,8 @@ pub fn aws_summary(
             no_color,
             hide_descriptions,
             abused_aws_api_values,
+            output_type,
+            clobber,
         );
     } else if let Some(f) = file {
         let log_contents = get_content(f);
@@ -280,144 +414,233 @@ pub fn aws_summary(
                 no_color,
                 hide_descriptions,
                 abused_aws_api_values,
+                output_type,
+                clobber,
             );
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// 出力処理
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
 fn output_summary(
     user_data: &HashMap<String, CTSummary>,
     output: &Path,
     no_color: bool,
     hide_descriptions: &bool,
     abused_aws_api_disc: Vec<String>,
+    output_type: u8,
+    clobber: bool,
 ) {
     if user_data.is_empty() {
         p(Some(Color::Rgb(255, 0, 0)), "No events found.", true);
         return;
     }
 
-    let mut csv_path = output.to_path_buf();
-    if csv_path.extension().and_then(|ext| ext.to_str()) != Some("csv") {
+    let output_csv = matches!(output_type, 1 | 4 | 5);
+    let output_json = matches!(output_type, 2 | 4);
+    let output_jsonl = matches!(output_type, 3 | 5);
+
+    let mut output_paths: Vec<PathBuf> = Vec::new();
+
+    // --- CSV 出力 ---
+    if output_csv {
+        let mut csv_path = output.to_path_buf();
         csv_path.set_extension("csv");
+
+        if !clobber && csv_path.exists() {
+            p(
+                Some(Color::Rgb(255, 0, 0)),
+                &format!(
+                    "The file {} already exists. Use --clobber to overwrite.",
+                    csv_path.display()
+                ),
+                true,
+            );
+            return;
+        }
+
+        let fmt_key_total =
+            |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
+                let total: usize = map.keys().len();
+                let total = total.to_formatted_string(&Locale::en);
+                let mut result = vec![format!("{}: {}", msg, total)];
+                result.extend(
+                    map.iter()
+                        .sorted_by(|a, b| b.1.cmp(a.1))
+                        .map(|(k, v)| {
+                            format!(
+                                "{} - {} ({} ~ {})",
+                                v.0.to_formatted_string(&Locale::en),
+                                k,
+                                v.1.replace('Z', "").replace('T', " "),
+                                v.2.replace('Z', "").replace('T', " ")
+                            )
+                        }),
+                );
+                result.join("\n")
+            };
+
+        let fmt_val_total =
+            |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
+                let total: usize = map.values().map(|v| v.0).sum();
+                let total = total.to_formatted_string(&Locale::en);
+                format!("| {msg} {total}")
+            };
+
+        let mut csv_wtr = get_writer(&Some(csv_path.clone()));
+        let csv_header = vec![
+            "UserARN",
+            "NumOfEvents",
+            "FirstTimestamp",
+            "LastTimestamp",
+            "AbusedAPIs-Success",
+            "AbusedAPIs-Failed",
+            "OtherAPIs-Success",
+            "OtherAPIs-Failed",
+            "AWS-Regions",
+            "SrcIPs",
+            "UserTypes",
+            "UserAccessKeyIDs",
+            "UserAgents",
+        ];
+        csv_wtr.write_record(&csv_header).unwrap();
+
+        let mut sorted_user_data: Vec<_> = user_data.iter().collect();
+        sorted_user_data.sort_by_key(|b| std::cmp::Reverse(b.1.num_of_events));
+
+        for (user_arn, summary) in sorted_user_data.iter() {
+            let num_of_events = summary.num_of_events.to_formatted_string(&Locale::en);
+            let first_timestamp = summary
+                .first_timestamp
+                .clone()
+                .replace("T", " ")
+                .replace("Z", "");
+            let last_timestamp = summary
+                .last_timestamp
+                .clone()
+                .replace("T", " ")
+                .replace("Z", "");
+            let aws_regions = fmt_key_total("Total regions", &summary.aws_regions);
+            let src_ips = fmt_key_total("Total source IPs", &summary.src_ips);
+            let user_types = &summary.user_types;
+            let access_key_ids = fmt_key_total("Total access key IDs", &summary.access_key_ids);
+            let user_agents = fmt_key_total("Total user agents", &summary.user_agents);
+
+            let mut abused_suc = fmt_key_total("Unique APIs", &summary.abused_api_success);
+            if let Some(pos) = abused_suc.find('\n') {
+                let abused_suc_val = fmt_val_total("Total APIs", &summary.abused_api_success);
+                abused_suc.insert_str(pos, &format!(" {abused_suc_val}"));
+            }
+            let mut abused_fai = fmt_key_total("Unique APIs", &summary.abused_api_failed);
+            if let Some(pos) = abused_fai.find('\n') {
+                let abused_fai_val = fmt_val_total("Total APIs", &summary.abused_api_failed);
+                abused_fai.insert_str(pos, &format!(" {abused_fai_val}"));
+            }
+            let mut other_suc = fmt_key_total("Unique APIs", &summary.other_api_success);
+            if let Some(pos) = other_suc.find('\n') {
+                let other_suc_val = fmt_val_total("Total APIs", &summary.other_api_success);
+                other_suc.insert_str(pos, &format!(" {other_suc_val}"));
+            }
+            let mut other_fai = fmt_key_total("Unique APIs", &summary.other_api_failed);
+            if let Some(pos) = other_fai.find('\n') {
+                let other_fai_val = fmt_val_total("Total APIs", &summary.other_api_failed);
+                other_fai.insert_str(pos, &format!(" {other_fai_val}"));
+            }
+
+            if *hide_descriptions {
+                abused_aws_api_disc.iter().for_each(|disc| {
+                    abused_suc = abused_suc.replace(disc, "");
+                    abused_fai = abused_fai.replace(disc, "");
+                });
+                abused_suc = abused_suc.replace("-  (2", "(2");
+                abused_fai = abused_fai.replace("-  (2", "(2");
+            }
+
+            csv_wtr
+                .write_record(vec![
+                    user_arn,
+                    &num_of_events,
+                    &first_timestamp,
+                    &last_timestamp,
+                    &abused_suc,
+                    &abused_fai,
+                    &other_suc,
+                    &other_fai,
+                    &aws_regions,
+                    &src_ips,
+                    &user_types,
+                    &access_key_ids,
+                    &user_agents,
+                ])
+                .unwrap();
+        }
+        csv_wtr.flush().unwrap();
+        output_paths.push(csv_path);
     }
-    let mut csv_wtr = get_writer(&Some(csv_path.clone()));
-    let csv_header = vec![
-        "UserARN",
-        "NumOfEvents",
-        "FirstTimestamp",
-        "LastTimestamp",
-        "AbusedAPIs-Success",
-        "AbusedAPIs-Failed",
-        "OtherAPIs-Success",
-        "OtherAPIs-Failed",
-        "AWS-Regions",
-        "SrcIPs",
-        "UserTypes",
-        "UserAccessKeyIDs",
-        "UserAgents",
-    ];
 
-    csv_wtr.write_record(&csv_header).unwrap();
+    // --- JSON 出力 ---
+    if output_json {
+        let mut json_path = output.to_path_buf();
+        json_path.set_extension("json");
 
-    let mut sorted_user_data: Vec<_> = user_data.iter().collect();
-    sorted_user_data.sort_by_key(|b| std::cmp::Reverse(b.1.num_of_events));
-
-    let fmt_key_total = |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
-        let total: usize = map.keys().len();
-        let total = total.to_formatted_string(&Locale::en);
-        let mut result = vec![format!("{}: {}", msg, total)];
-        result.extend(
-            map.iter()
-                .sorted_by(|a, b| b.1.cmp(a.1)) // 件数の多い順にソート
-                .map(|(k, v)| {
-                    format!(
-                        "{} - {} ({} ~ {})",
-                        v.0.to_formatted_string(&Locale::en),
-                        k,
-                        v.1.replace('Z', "").replace('T', " "),
-                        v.2.replace('Z', "").replace('T', " ")
-                    )
-                }),
-        );
-        result.join("\n")
-    };
-
-    let fmt_val_total = |msg: &str, map: &HashMap<String, (usize, String, String)>| -> String {
-        let total: usize = map.values().map(|v| v.0).sum();
-        let total = total.to_formatted_string(&Locale::en);
-        format!("| {msg} {total}")
-    };
-
-    for (user_arn, summary) in sorted_user_data.iter() {
-        let num_of_events = summary.num_of_events.to_formatted_string(&Locale::en);
-        let first_timestamp = summary
-            .first_timestamp
-            .clone()
-            .replace("T", " ")
-            .replace("Z", "");
-        let last_timestamp = summary
-            .last_timestamp
-            .clone()
-            .replace("T", " ")
-            .replace("Z", "");
-        let aws_regions = fmt_key_total("Total regions", &summary.aws_regions);
-        let src_ips = fmt_key_total("Total source IPs", &summary.src_ips);
-        let user_types = &summary.user_types;
-        let access_key_ids = fmt_key_total("Total access key IDs", &summary.access_key_ids);
-        let user_agents = fmt_key_total("Total user agents", &summary.user_agents);
-
-        let mut abused_suc = fmt_key_total("Unique APIs", &summary.abused_api_success);
-        if let Some(pos) = abused_suc.find('\n') {
-            let abused_suc_val = fmt_val_total("Total APIs", &summary.abused_api_success);
-            abused_suc.insert_str(pos, &format!(" {abused_suc_val}"));
-        }
-        let mut abused_fai = fmt_key_total("Unique APIs", &summary.abused_api_failed);
-        if let Some(pos) = abused_fai.find('\n') {
-            let abused_fai_val = fmt_val_total("Total APIs", &summary.abused_api_failed);
-            abused_fai.insert_str(pos, &format!(" {abused_fai_val}"));
-        }
-        let mut other_suc = fmt_key_total("Unique APIs", &summary.other_api_success);
-        if let Some(pos) = other_suc.find('\n') {
-            let other_suc_val = fmt_val_total("Total APIs", &summary.other_api_success);
-            other_suc.insert_str(pos, &format!(" {other_suc_val}"));
-        }
-        let mut other_fai = fmt_key_total("Unique APIs", &summary.other_api_failed);
-        if let Some(pos) = other_fai.find('\n') {
-            let other_fai_val = fmt_val_total("Total APIs", &summary.other_api_failed);
-            other_fai.insert_str(pos, &format!(" {other_fai_val}"));
+        if !clobber && json_path.exists() {
+            p(
+                Some(Color::Rgb(255, 0, 0)),
+                &format!(
+                    "The file {} already exists. Use --clobber to overwrite.",
+                    json_path.display()
+                ),
+                true,
+            );
+            return;
         }
 
-        if *hide_descriptions {
-            abused_aws_api_disc.iter().for_each(|disc| {
-                abused_suc = abused_suc.replace(disc, "");
-                abused_fai = abused_fai.replace(disc, "");
-            });
-            abused_suc = abused_suc.replace("-  (2", "(2");
-            abused_fai = abused_fai.replace("-  (2", "(2");
-        }
-
-        csv_wtr
-            .write_record(vec![
-                user_arn,
-                &num_of_events,
-                &first_timestamp,
-                &last_timestamp,
-                &abused_suc,
-                &abused_fai,
-                &other_suc,
-                &other_fai,
-                &aws_regions,
-                &src_ips,
-                &user_types,
-                &access_key_ids,
-                &user_agents,
-            ])
-            .unwrap();
+        let records = build_json_records(user_data, *hide_descriptions);
+        let file = File::create(&json_path).unwrap();
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, &records).unwrap();
+        writer.flush().unwrap();
+        output_paths.push(json_path);
     }
-    csv_wtr.flush().unwrap();
-    output_path_info(no_color, [csv_path].as_slice(), true);
+
+    // --- JSONL 出力 ---
+    if output_jsonl {
+        let mut jsonl_path = output.to_path_buf();
+        jsonl_path.set_extension("jsonl");
+
+        if !clobber && jsonl_path.exists() {
+            p(
+                Some(Color::Rgb(255, 0, 0)),
+                &format!(
+                    "The file {} already exists. Use --clobber to overwrite.",
+                    jsonl_path.display()
+                ),
+                true,
+            );
+            return;
+        }
+
+        let records = build_json_records(user_data, *hide_descriptions);
+        let file = File::create(&jsonl_path).unwrap();
+        let mut writer = BufWriter::new(file);
+        for record in &records {
+            let line = serde_json::to_string(record).unwrap();
+            writeln!(writer, "{}", line).unwrap();
+        }
+        writer.flush().unwrap();
+        output_paths.push(jsonl_path);
+    }
+
+    output_path_info(no_color, output_paths.as_slice(), true);
 }
+
+// ---------------------------------------------------------------------------
+// abused_aws_api_calls.csv 読み込み
+// ---------------------------------------------------------------------------
 
 fn read_abused_aws_api_calls(file_path: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
@@ -445,3 +668,392 @@ fn read_abused_aws_api_calls(file_path: &str) -> HashMap<String, String> {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    /// テスト用の CTSummary を生成するヘルパー
+    fn make_test_summary() -> CTSummary {
+        let mut s = CTSummary::default();
+        s.add_event(
+            "2024-01-01T00:00:00Z".to_string(),
+            "us-east-1".to_string(),
+            "1.2.3.4".to_string(),
+            "IAMUser".to_string(),
+            "AKIAIOSFODNN7EXAMPLE".to_string(),
+            "aws-cli/2.0".to_string(),
+            "ListBuckets (s3.amazonaws.com) - List all S3 buckets".to_string(),
+            "".to_string(),
+            "".to_string(),
+            "".to_string(),
+        );
+        s.add_event(
+            "2024-01-02T00:00:00Z".to_string(),
+            "us-west-2".to_string(),
+            "5.6.7.8".to_string(),
+            "IAMUser".to_string(),
+            "AKIAIOSFODNN7EXAMPLE".to_string(),
+            "aws-sdk/1.0".to_string(),
+            "".to_string(),
+            "".to_string(),
+            "GetObject (s3.amazonaws.com)".to_string(),
+            "".to_string(),
+        );
+        s
+    }
+
+    // -----------------------------------------------------------------------
+    // CTSummary::add_event のテスト
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_ct_summary_num_of_events() {
+        let summary = make_test_summary();
+        assert_eq!(summary.num_of_events, 2);
+    }
+
+    #[test]
+    fn test_ct_summary_timestamps() {
+        let summary = make_test_summary();
+        assert_eq!(summary.first_timestamp, "2024-01-01T00:00:00Z");
+        assert_eq!(summary.last_timestamp, "2024-01-02T00:00:00Z");
+    }
+
+    #[test]
+    fn test_ct_summary_regions() {
+        let summary = make_test_summary();
+        assert_eq!(summary.aws_regions.len(), 2);
+        assert!(summary.aws_regions.contains_key("us-east-1"));
+        assert!(summary.aws_regions.contains_key("us-west-2"));
+    }
+
+    #[test]
+    fn test_ct_summary_abused_api_success() {
+        let summary = make_test_summary();
+        assert_eq!(summary.abused_api_success.len(), 1);
+        assert!(
+            summary
+                .abused_api_success
+                .contains_key("ListBuckets (s3.amazonaws.com) - List all S3 buckets")
+        );
+    }
+
+    #[test]
+    fn test_ct_summary_other_api_success() {
+        let summary = make_test_summary();
+        assert_eq!(summary.other_api_success.len(), 1);
+        assert!(
+            summary
+                .other_api_success
+                .contains_key("GetObject (s3.amazonaws.com)")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // map_to_api_entries のテスト
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_map_to_api_entries_with_description() {
+        let mut map = HashMap::new();
+        map.insert(
+            "ListBuckets (s3.amazonaws.com) - List all S3 buckets".to_string(),
+            (3usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-02T00:00:00Z".to_string()),
+        );
+        let entries = map_to_api_entries(&map, false);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].api, "ListBuckets (s3.amazonaws.com)");
+        assert_eq!(entries[0].description, "List all S3 buckets");
+        assert_eq!(entries[0].count, 3);
+        assert_eq!(entries[0].first_seen, "2024-01-01 00:00:00");
+        assert_eq!(entries[0].last_seen, "2024-01-02 00:00:00");
+    }
+
+    #[test]
+    fn test_map_to_api_entries_hide_description() {
+        let mut map = HashMap::new();
+        map.insert(
+            "ListBuckets (s3.amazonaws.com) - List all S3 buckets".to_string(),
+            (1usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+        );
+        let entries = map_to_api_entries(&map, true);
+        assert_eq!(entries[0].api, "ListBuckets (s3.amazonaws.com)");
+        assert_eq!(entries[0].description, "");
+    }
+
+    #[test]
+    fn test_map_to_api_entries_no_description() {
+        let mut map = HashMap::new();
+        map.insert(
+            "GetObject (s3.amazonaws.com)".to_string(),
+            (2usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+        );
+        let entries = map_to_api_entries(&map, false);
+        assert_eq!(entries[0].api, "GetObject (s3.amazonaws.com)");
+        assert_eq!(entries[0].description, "");
+    }
+
+    #[test]
+    fn test_map_to_api_entries_sorted_by_count_desc() {
+        let mut map = HashMap::new();
+        map.insert(
+            "ApiA (src)".to_string(),
+            (1usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+        );
+        map.insert(
+            "ApiB (src)".to_string(),
+            (5usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+        );
+        map.insert(
+            "ApiC (src)".to_string(),
+            (3usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+        );
+        let entries = map_to_api_entries(&map, false);
+        assert_eq!(entries[0].count, 5);
+        assert_eq!(entries[1].count, 3);
+        assert_eq!(entries[2].count, 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // map_to_count_entries のテスト
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_map_to_count_entries_basic() {
+        let mut map = HashMap::new();
+        map.insert(
+            "us-east-1".to_string(),
+            (10usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-02T00:00:00Z".to_string()),
+        );
+        let entries = map_to_count_entries(&map);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].value, "us-east-1");
+        assert_eq!(entries[0].count, 10);
+        assert_eq!(entries[0].first_seen, "2024-01-01 00:00:00");
+        assert_eq!(entries[0].last_seen, "2024-01-02 00:00:00");
+    }
+
+    #[test]
+    fn test_map_to_count_entries_sorted_by_count_desc() {
+        let mut map = HashMap::new();
+        map.insert(
+            "us-east-1".to_string(),
+            (2usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+        );
+        map.insert(
+            "eu-west-1".to_string(),
+            (8usize, "2024-01-01T00:00:00Z".to_string(), "2024-01-01T00:00:00Z".to_string()),
+        );
+        let entries = map_to_count_entries(&map);
+        assert_eq!(entries[0].value, "eu-west-1");
+        assert_eq!(entries[1].value, "us-east-1");
+    }
+
+    // -----------------------------------------------------------------------
+    // build_json_records のテスト
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_json_records_basic() {
+        let mut user_data = HashMap::new();
+        user_data.insert("arn:aws:iam::123:user/alice".to_string(), make_test_summary());
+
+        let records = build_json_records(&user_data, false);
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].user_arn, "arn:aws:iam::123:user/alice");
+        assert_eq!(records[0].num_of_events, 2);
+        assert_eq!(records[0].first_timestamp, "2024-01-01 00:00:00");
+        assert_eq!(records[0].last_timestamp, "2024-01-02 00:00:00");
+        assert_eq!(records[0].aws_regions.len(), 2);
+        assert_eq!(records[0].abused_apis_success.len(), 1);
+        assert_eq!(records[0].other_apis_success.len(), 1);
+    }
+
+    #[test]
+    fn test_build_json_records_sorted_by_events_desc() {
+        let mut user_data = HashMap::new();
+        let mut summary_alice = CTSummary::default();
+        summary_alice.num_of_events = 5;
+        let mut summary_bob = CTSummary::default();
+        summary_bob.num_of_events = 20;
+
+        user_data.insert("arn:aws:iam::123:user/alice".to_string(), summary_alice);
+        user_data.insert("arn:aws:iam::123:user/bob".to_string(), summary_bob);
+
+        let records = build_json_records(&user_data, false);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].num_of_events, 20); // bob が先
+        assert_eq!(records[1].num_of_events, 5);  // alice が後
+    }
+
+    #[test]
+    fn test_build_json_records_hide_descriptions() {
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        let records = build_json_records(&user_data, true);
+        // hide_descriptions=true のとき description は空文字
+        assert_eq!(records[0].abused_apis_success[0].description, "");
+    }
+
+    // -----------------------------------------------------------------------
+    // output_summary のテスト (出力ファイル生成確認)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_output_type_1_creates_csv_only() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 1, false);
+
+        assert!(tmp.path().join("result.csv").exists());
+        assert!(!tmp.path().join("result.json").exists());
+        assert!(!tmp.path().join("result.jsonl").exists());
+    }
+
+    #[test]
+    fn test_output_type_2_creates_json_only() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 2, false);
+
+        assert!(!tmp.path().join("result.csv").exists());
+        assert!(tmp.path().join("result.json").exists());
+        assert!(!tmp.path().join("result.jsonl").exists());
+    }
+
+    #[test]
+    fn test_output_type_3_creates_jsonl_only() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 3, false);
+
+        assert!(!tmp.path().join("result.csv").exists());
+        assert!(!tmp.path().join("result.json").exists());
+        assert!(tmp.path().join("result.jsonl").exists());
+    }
+
+    #[test]
+    fn test_output_type_4_creates_csv_and_json() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 4, false);
+
+        assert!(tmp.path().join("result.csv").exists());
+        assert!(tmp.path().join("result.json").exists());
+        assert!(!tmp.path().join("result.jsonl").exists());
+    }
+
+    #[test]
+    fn test_output_type_5_creates_csv_and_jsonl() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 5, false);
+
+        assert!(tmp.path().join("result.csv").exists());
+        assert!(!tmp.path().join("result.json").exists());
+        assert!(tmp.path().join("result.jsonl").exists());
+    }
+
+    #[test]
+    fn test_output_json_valid_structure() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn:aws:iam::123:user/alice".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 2, false);
+
+        let content = std::fs::read_to_string(tmp.path().join("result.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["user_arn"], "arn:aws:iam::123:user/alice");
+        assert_eq!(arr[0]["num_of_events"], 2);
+    }
+
+    #[test]
+    fn test_output_jsonl_each_line_is_valid_json() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::a".to_string(), make_test_summary());
+        user_data.insert("arn::b".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 3, false);
+
+        let content = std::fs::read_to_string(tmp.path().join("result.jsonl")).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        for line in lines {
+            assert!(serde_json::from_str::<serde_json::Value>(line).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_clobber_false_does_not_overwrite_existing_json() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+        let json_path = tmp.path().join("result.json");
+
+        // 先にファイルを作成
+        std::fs::write(&json_path, "original").unwrap();
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 2, false);
+
+        // 上書きされていないこと
+        let content = std::fs::read_to_string(&json_path).unwrap();
+        assert_eq!(content, "original");
+    }
+
+    #[test]
+    fn test_clobber_true_overwrites_existing_json() {
+        let tmp = TempDir::new().unwrap();
+        let output_path = tmp.path().join("result");
+        let json_path = tmp.path().join("result.json");
+
+        std::fs::write(&json_path, "original").unwrap();
+
+        let mut user_data = HashMap::new();
+        user_data.insert("arn::test".to_string(), make_test_summary());
+
+        output_summary(&user_data, &output_path, true, &false, vec![], 2, true);
+
+        let content = std::fs::read_to_string(&json_path).unwrap();
+        assert_ne!(content, "original");
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,8 @@ fn main() {
             hide_descriptions,
             geo_ip,
             common_opt,
+            output_type,
+            clobber,
         } => {
             display_logo(common_opt.quiet, no_color, true, false);
             if !check_path_exists(input_opt.filepath.clone(), input_opt.directory.clone()) {
@@ -190,6 +192,8 @@ fn main() {
                 include_sts,
                 hide_descriptions,
                 geo_ip,
+                *output_type,
+                *clobber,
             );
         }
         UpdateRules { common_opt } => {

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -252,19 +252,19 @@ pub enum Commands {
         clobber: bool,
 
         /// Save the results to a file
-        #[arg(help_heading = Some("Output"), short, long, value_name = "FILE", required = true, display_order = 302)]
+        #[arg(help_heading = Some("Output"), short, long, value_name = "FILE", required = true, display_order = 303)]
         output: PathBuf,
 
         /// Output type 1: CSV (default), 2: JSON, 3: JSONL, 4: CSV & JSON, 5: CSV & JSONL
-        #[arg(help_heading = Some("Output"), short = 't', long = "output-type", value_parser = clap::value_parser!(u8).range(1..=5), default_value = "1", display_order = 303)]
+        #[arg(help_heading = Some("Output"), short = 't', long = "output-type", value_parser = clap::value_parser!(u8).range(1..=5), default_value = "1", display_order = 304)]
         output_type: u8,
 
         /// Hide description of the commonly abused API calls
-        #[arg(help_heading = Some("Output"), short = 'D', long = "hide-descriptions", display_order = 304)]
+        #[arg(help_heading = Some("Output"), short = 'D', long = "hide-descriptions", display_order = 301)]
         hide_descriptions: bool,
 
         /// Add GeoIP (ASN, city, country) info to IP addresses
-        #[arg(help_heading = Some("Output"), short = 'G', long = "geo-ip", visible_alias = "GeoIP", value_name = "MAXMIND-DB-DIR", display_order = 305)]
+        #[arg(help_heading = Some("Output"), short = 'G', long = "geo-ip", visible_alias = "GeoIP", value_name = "MAXMIND-DB-DIR", display_order = 302)]
         geo_ip: Option<PathBuf>,
 
         #[clap(flatten)]

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -247,16 +247,24 @@ pub enum Commands {
         #[arg(help_heading = Some("Filtering"), short = 's', long = "include-sts-keys")]
         include_sts: bool,
 
-        /// Output results to a CSV file
-        #[arg(help_heading = Some("Output"), short, long, value_name = "FILE", required = true)]
+        /// Overwrite files when saving
+        #[arg(help_heading = Some("Output"), short = 'C', long = "clobber", display_order = 300)]
+        clobber: bool,
+
+        /// Save the results to a file
+        #[arg(help_heading = Some("Output"), short, long, value_name = "FILE", required = true, display_order = 302)]
         output: PathBuf,
 
+        /// Output type 1: CSV (default), 2: JSON, 3: JSONL, 4: CSV & JSON, 5: CSV & JSONL
+        #[arg(help_heading = Some("Output"), short = 't', long = "output-type", value_parser = clap::value_parser!(u8).range(1..=5), default_value = "1", display_order = 303)]
+        output_type: u8,
+
         /// Hide description of the commonly abused API calls
-        #[arg(help_heading = Some("Output"), short = 'D', long = "hide-descriptions")]
+        #[arg(help_heading = Some("Output"), short = 'D', long = "hide-descriptions", display_order = 304)]
         hide_descriptions: bool,
 
         /// Add GeoIP (ASN, city, country) info to IP addresses
-        #[arg(help_heading = Some("Output"), short = 'G', long = "GeoIP", value_name = "MAXMIND-DB-DIR")]
+        #[arg(help_heading = Some("Output"), short = 'G', long = "GeoIP", value_name = "MAXMIND-DB-DIR", display_order = 305)]
         geo_ip: Option<PathBuf>,
 
         #[clap(flatten)]

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -264,7 +264,7 @@ pub enum Commands {
         hide_descriptions: bool,
 
         /// Add GeoIP (ASN, city, country) info to IP addresses
-        #[arg(help_heading = Some("Output"), short = 'G', long = "GeoIP", value_name = "MAXMIND-DB-DIR", display_order = 305)]
+        #[arg(help_heading = Some("Output"), short = 'G', long = "geo-ip", visible_alias = "GeoIP", value_name = "MAXMIND-DB-DIR", display_order = 305)]
         geo_ip: Option<PathBuf>,
 
         #[clap(flatten)]


### PR DESCRIPTION
## What Changed
Added `--output-type` option to the aws-ct-summary command to make it easier to use its output with other tools.
```
Output:
  -C, --clobber                    Overwrite files when saving
  -o, --output <FILE>              Save the results to a file
  -t, --output-type <OUTPUT_TYPE>  Output type 1: CSV (default), 2: JSON, 3: JSONL, 4: CSV & JSON, 5: CSV & JSONL [default: 1]
```

## Evidence
### Integration-Test
- https://github.com/Yamato-Security/suzaku/actions/runs/26224266312

I’d appreciate it if you could check it when you have time🙏