### PR TITLE
ci(docs): auto-enable GitHub Pages so the docs site deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,8 @@
 name: Deploy docs to GitHub Pages
 
 # Build the Material for MkDocs site in website/ and publish it to GitHub Pages.
-# One-time setup: Settings -> Pages -> Source: "GitHub Actions".
+# The "Configure Pages" step below enables Pages automatically (enablement: true),
+# so no manual "Settings -> Pages -> Source: GitHub Actions" step is required.
 
 on:
   push:
@@ -48,6 +49,12 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v6
+        # Auto-enable GitHub Pages (source: GitHub Actions) on the first run so the
+        # workflow provisions the Pages site itself. Without this, configure-pages
+        # fails with "Get Pages site failed ... Not Found" until someone manually sets
+        # Settings -> Pages -> Source: "GitHub Actions".
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## What Changed

- Add `enablement: true` to the `actions/configure-pages` step in `.github/workflows/docs.yml` so the workflow enables GitHub Pages itself (source: GitHub Actions), instead of requiring a manual **Settings → Pages** toggle.
- Update the header comment accordingly.

## Evidence

The documentation site at **https://yamato-security.github.io/suzaku/** currently returns **404** — it has never been published.

The cause is not the docs content or the build. The `docs.yml` workflow ran once ([run on 2026-06-29](https://github.com/Yamato-Security/suzaku/actions/workflows/docs.yml)) and got all the way through **`mkdocs build --strict`** successfully, then failed at the **Configure Pages** step:

```
enablement: false
##[error]Get Pages site failed. Please verify that the repository has Pages
enabled and configured to build using GitHub Actions ... Error: Not Found
##[error]HttpError: Not Found
```

`actions/configure-pages@v6` calls `GET /repos/{owner}/{repo}/pages`, which 404s when Pages has never been enabled for the repo. Because the `build` job fails there, the artifact is never uploaded and the `deploy` job is skipped — so nothing is published.

Sibling project Hayabusa uses the same workflow and its site is live only because Pages was enabled manually in its settings. This change lets the workflow provision Pages on its own, matching what the error message suggests (*"consider exploring the `enablement` parameter"*).

Since this PR modifies `.github/workflows/docs.yml` — which is in the workflow's own `paths` filter — **merging it triggers a `docs.yml` run that enables Pages and publishes the site** to https://yamato-security.github.io/suzaku/. No repository-settings change is required.

> Alternative (equivalent) fix that needs no code change: a maintainer sets **Settings → Pages → Source: "GitHub Actions"** and re-runs the failed workflow. This PR just makes that automatic and self-documenting.