### PR TITLE
ci: run the Rust PR workflow on Windows x86_64 only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,16 +14,19 @@ jobs:
       fail-fast: false
       matrix:
         info:
-          - {
-            os: "ubuntu-latest",
-            target: "x86_64-unknown-linux-gnu",
-            cross: false,
-          }
-          - {
-            os: "ubuntu-latest",
-            target: "x86_64-unknown-linux-musl",
-            cross: true,
-          }
+          # NOTE: Reduced to Windows x86_64 only to cut GitHub Actions usage.
+          # The full platform matrix still runs in release.yml. Uncomment the
+          # entries below to restore per-push/PR coverage for the other targets.
+          # - {
+          #   os: "ubuntu-latest",
+          #   target: "x86_64-unknown-linux-gnu",
+          #   cross: false,
+          # }
+          # - {
+          #   os: "ubuntu-latest",
+          #   target: "x86_64-unknown-linux-musl",
+          #   cross: true,
+          # }
           # - { os: "macOS-latest", target: "x86_64-apple-darwin", cross: false }
           # - { os: "macOS-latest", target: "aarch64-apple-darwin", cross: false }
           - {
@@ -31,11 +34,11 @@ jobs:
             target: "x86_64-pc-windows-msvc",
             cross: false,
           }
-          - {
-            os: "windows-latest",
-            target: "i686-pc-windows-msvc",
-            cross: true,
-          }
+          # - {
+          #   os: "windows-latest",
+          #   target: "i686-pc-windows-msvc",
+          #   cross: true,
+          # }
     runs-on: ${{ matrix.info.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What

Reduce the per-PR `Rust` workflow (`.github/workflows/rust.yml`) matrix from four targets to **just `windows-latest` / `x86_64-pc-windows-msvc`**, to cut GitHub Actions usage.

The other three entries (ubuntu gnu, ubuntu musl, windows i686) are **commented out**, not deleted — uncomment them any time to restore full per-push/PR coverage. The build/clippy/test steps are untouched, and the **full platform matrix still runs in `release.yml`** (windows x64/i686/aarch64, linux gnu/musl/aarch64, macOS x64/aarch64), so released binaries are unaffected.

Mirrors the same change made to hayabusa-pro's `rust.yml`.

> Note: this repo is public, so standard GitHub-hosted runner minutes are free — the savings mainly apply if you use larger/self-hosted runners; either way PRs now finish faster with one job instead of four.