### PR TITLE
Add ignore-list support to skip loading rules by UUID

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -6,6 +6,7 @@
 
 - Azureログ用のDFIRタイムラインを作成する`azure-timeline`コマンドを追加した。 (#109) (@fukusuket)
 - CloudTrailログを検索するための`aws-ct-search`コマンドを追加した。(#117) (@fukusuket)
+- UUIDを指定してルールを読み込み対象から除外できる除外リストファイル（`config/aws_ignore_rule_list.txt`）に対応した。これにより、置き換えられた重複ルールをリポジトリに残したまま読み込まないようにできる。 (#136) (@YamatoSecurity)
 
 **改善:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added the `azure-timeline` command to create a DFIR timeline for Azure logs. (#109) (@fukusuket)
 - New `aws-ct-search` command to search through CloudTrail logs. (#117) (@fukusuket)
+- Added support for an ignore-list file (`config/aws_ignore_rule_list.txt`) to skip loading rules by UUID, so superseded/duplicate rules can stay in the repo without being loaded. (#136) (@YamatoSecurity)
 
 **Enhancements:**
 

--- a/src/core/log_source.rs
+++ b/src/core/log_source.rs
@@ -15,6 +15,15 @@ impl LogSource {
         }
     }
 
+    /// File name (under the rules directory's `config/`) listing rule UUIDs to skip loading.
+    pub fn ignore_rule_list_filename(&self) -> &str {
+        match self {
+            LogSource::Aws => "aws_ignore_rule_list.txt",
+            LogSource::Azure => "azure_ignore_rule_list.txt",
+            LogSource::All => "",
+        }
+    }
+
     pub fn supported_services(&self) -> &[&str] {
         match self {
             LogSource::Aws => &["cloudtrail"],

--- a/src/core/rules.rs
+++ b/src/core/rules.rs
@@ -1,8 +1,9 @@
 use crate::core::log_source::LogSource;
 use sigma_rust::Rule;
 use sigma_rust::rule_from_yaml;
+use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn load_correlation_yamls_from_dir(path: &PathBuf) -> Vec<String> {
     let mut yaml_contents = Vec::new();
@@ -77,6 +78,59 @@ fn load_rules_recursive(directory: &PathBuf, rules: &mut Vec<Rule>, log: &LogSou
             }
         }
     }
+}
+
+/// Path to the ignore-list file for a log source, resolved relative to the rules directory
+/// (its parent when a single rule file is passed): `<rules-dir>/config/<log>_ignore_rule_list.txt`.
+pub fn ignore_rule_list_path(rules_path: &Path, log: &LogSource) -> PathBuf {
+    let base = if rules_path.is_dir() {
+        rules_path.to_path_buf()
+    } else {
+        rules_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_default()
+    };
+    base.join("config").join(log.ignore_rule_list_filename())
+}
+
+/// Read a set of rule UUIDs to skip from an ignore-list file. Format: one UUID per line;
+/// blank lines and lines starting with `#` are ignored; an inline `# comment` after the
+/// UUID is allowed. Returns an empty set if the file does not exist.
+pub fn load_ignore_rule_ids(path: &Path) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    if let Ok(contents) = fs::read_to_string(path) {
+        for line in contents.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some(id) = line
+                .split('#')
+                .next()
+                .and_then(|s| s.split_whitespace().next())
+            {
+                ids.insert(id.to_string());
+            }
+        }
+    }
+    ids
+}
+
+/// Drop any rule whose `id` is in `ignore_ids`. Rules without an `id` are kept.
+pub fn filter_ignored_rules(rules: Vec<Rule>, ignore_ids: &HashSet<String>) -> Vec<Rule> {
+    if ignore_ids.is_empty() {
+        return rules;
+    }
+    rules
+        .into_iter()
+        .filter(|rule| {
+            rule.id
+                .as_deref()
+                .map(|id| !ignore_ids.contains(id))
+                .unwrap_or(true)
+        })
+        .collect()
 }
 
 fn level_to_int(level: &str) -> u8 {
@@ -213,6 +267,78 @@ detection:
         let rules = load_rules_from_dir(&dir_path, &LogSource::All);
 
         assert_eq!(rules.len(), 1); // Only .yml file should be loaded
+    }
+
+    fn make_rule_with_id(id: &str) -> Rule {
+        let yaml = format!(
+            r#"
+            title: Test Rule
+            id: {id}
+            level: medium
+            logsource:
+              product: aws
+              service: cloudtrail
+            detection:
+              selection:
+                field: value
+              condition: selection
+            "#
+        );
+        rule_from_yaml(&yaml).unwrap()
+    }
+
+    #[test]
+    fn test_load_ignore_rule_ids_parses_and_skips_comments() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("aws_ignore_rule_list.txt");
+        fs::write(
+            &file_path,
+            "# header comment\n\
+             07330162-dba1-4746-8121-a9647d49d297 # some rule -- superseded\n\
+             \n\
+             2070cb71-0958-4504-906f-f8d4163d7505\n\
+             # trailing comment line\n",
+        )
+        .unwrap();
+
+        let ids = load_ignore_rule_ids(&file_path);
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("07330162-dba1-4746-8121-a9647d49d297"));
+        assert!(ids.contains("2070cb71-0958-4504-906f-f8d4163d7505"));
+    }
+
+    #[test]
+    fn test_load_ignore_rule_ids_missing_file_is_empty() {
+        let ids = load_ignore_rule_ids(&PathBuf::from("/nonexistent/ignore.txt"));
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_filter_ignored_rules() {
+        let rules = vec![
+            make_rule_with_id("keep-1"),
+            make_rule_with_id("drop-me"),
+            make_rule_with_id("keep-2"),
+        ];
+        let ignore: HashSet<String> = ["drop-me".to_string()].into_iter().collect();
+
+        let filtered = filter_ignored_rules(rules, &ignore);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().all(|r| r.id.as_deref() != Some("drop-me")));
+    }
+
+    #[test]
+    fn test_filter_ignored_rules_empty_set_is_noop() {
+        let rules = vec![make_rule_with_id("a"), make_rule_with_id("b")];
+        let filtered = filter_ignored_rules(rules, &HashSet::new());
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn test_ignore_rule_list_path_for_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = ignore_rule_list_path(temp_dir.path(), &LogSource::Aws);
+        assert!(path.ends_with("config/aws_ignore_rule_list.txt"));
     }
 
     #[test]

--- a/src/core/rules.rs
+++ b/src/core/rules.rs
@@ -117,6 +117,11 @@ pub fn load_ignore_rule_ids(path: &Path) -> HashSet<String> {
     ids
 }
 
+/// True if `id` is present in the ignore set. Rules without an id are never ignored.
+pub fn is_ignored(id: Option<&str>, ignore_ids: &HashSet<String>) -> bool {
+    id.map(|id| ignore_ids.contains(id)).unwrap_or(false)
+}
+
 /// Drop any rule whose `id` is in `ignore_ids`. Rules without an `id` are kept.
 pub fn filter_ignored_rules(rules: Vec<Rule>, ignore_ids: &HashSet<String>) -> Vec<Rule> {
     if ignore_ids.is_empty() {
@@ -124,12 +129,7 @@ pub fn filter_ignored_rules(rules: Vec<Rule>, ignore_ids: &HashSet<String>) -> V
     }
     rules
         .into_iter()
-        .filter(|rule| {
-            rule.id
-                .as_deref()
-                .map(|id| !ignore_ids.contains(id))
-                .unwrap_or(true)
-        })
+        .filter(|rule| !is_ignored(rule.id.as_deref(), ignore_ids))
         .collect()
 }
 
@@ -325,6 +325,14 @@ detection:
         let filtered = filter_ignored_rules(rules, &ignore);
         assert_eq!(filtered.len(), 2);
         assert!(filtered.iter().all(|r| r.id.as_deref() != Some("drop-me")));
+    }
+
+    #[test]
+    fn test_is_ignored() {
+        let ignore: HashSet<String> = ["drop-me".to_string()].into_iter().collect();
+        assert!(is_ignored(Some("drop-me"), &ignore));
+        assert!(!is_ignored(Some("keep-me"), &ignore));
+        assert!(!is_ignored(None, &ignore)); // rules without an id are never ignored
     }
 
     #[test]

--- a/src/core/timeline.rs
+++ b/src/core/timeline.rs
@@ -34,6 +34,13 @@ pub fn make_timeline(options: &TimelineOptions, common_opt: &CommonOptions, log:
     }
     let profile = load_profile(&log, &geo_search, false);
     let rules: Vec<Rule> = rules::load_rules_from_dir(&options.rules, &log);
+    // Skip rules listed in <rules-dir>/config/<log>_ignore_rule_list.txt (superseded/duplicate
+    // rules that stay in the repo but should not be loaded).
+    let ignore_ids =
+        rules::load_ignore_rule_ids(&rules::ignore_rule_list_path(&options.rules, &log));
+    let loaded_rule_count = rules.len();
+    let rules: Vec<Rule> = rules::filter_ignored_rules(rules, &ignore_ids);
+    let ignored_rule_count = loaded_rule_count - rules.len();
     let rules = rules::filter_rules_by_level(&rules, &options.min_level);
     let correlation_rules = rules::load_correlation_yamls_from_dir(&options.rules);
     if rules.is_empty() && correlation_rules.is_empty() {
@@ -80,6 +87,14 @@ pub fn make_timeline(options: &TimelineOptions, common_opt: &CommonOptions, log:
 
     p(Green.rdg(no_color), "Total detection rules: ", false);
     p(None, rules.len().to_string().as_str(), true);
+    if ignored_rule_count > 0 {
+        p(
+            Green.rdg(no_color),
+            "Rules skipped via ignore-list: ",
+            false,
+        );
+        p(None, ignored_rule_count.to_string().as_str(), true);
+    }
     p(Green.rdg(no_color), "Total correlation rules: ", false);
     p(
         None,

--- a/src/core/timeline.rs
+++ b/src/core/timeline.rs
@@ -53,6 +53,7 @@ pub fn make_timeline(options: &TimelineOptions, common_opt: &CommonOptions, log:
     }
     let mut correlation_engine = CorrelationEngine::new();
     let mut total_correlation_rules = 0;
+    let mut ignored_correlation_count = 0;
     for yaml in &correlation_rules {
         match parse_rules_from_yaml(yaml.as_str()) {
             Ok(rules) => {
@@ -60,6 +61,12 @@ pub fn make_timeline(options: &TimelineOptions, common_opt: &CommonOptions, log:
                 let total_base_rules = base_rules.len();
                 let mut added_base_rules = 0;
                 for (name, rule) in base_rules {
+                    // Skip ignore-listed base rules; the correlation that depends on them is
+                    // then skipped too (added_base_rules never reaches total_base_rules).
+                    if rules::is_ignored(rule.id.as_deref(), &ignore_ids) {
+                        ignored_correlation_count += 1;
+                        continue;
+                    }
                     if let Some(ref service) = rule.logsource.service
                         && log.supported_services().contains(&service.as_str())
                     {
@@ -68,6 +75,10 @@ pub fn make_timeline(options: &TimelineOptions, common_opt: &CommonOptions, log:
                     }
                 }
                 for rule in correlation_rules {
+                    if rules::is_ignored(rule.id.as_deref(), &ignore_ids) {
+                        ignored_correlation_count += 1;
+                        continue;
+                    }
                     if added_base_rules == total_base_rules {
                         correlation_engine.add_correlation_rule(rule);
                         total_correlation_rules += 1;
@@ -87,13 +98,14 @@ pub fn make_timeline(options: &TimelineOptions, common_opt: &CommonOptions, log:
 
     p(Green.rdg(no_color), "Total detection rules: ", false);
     p(None, rules.len().to_string().as_str(), true);
-    if ignored_rule_count > 0 {
+    let total_ignored = ignored_rule_count + ignored_correlation_count;
+    if total_ignored > 0 {
         p(
             Green.rdg(no_color),
             "Rules skipped via ignore-list: ",
             false,
         );
-        p(None, ignored_rule_count.to_string().as_str(), true);
+        p(None, total_ignored.to_string().as_str(), true);
     }
     p(Green.rdg(no_color), "Total correlation rules: ", false);
     p(


### PR DESCRIPTION
Closes #135.

## Summary

Adds support for an **ignore-list file** so specific rules can be excluded from loading by their `id` (UUID), without deleting the rule files. This lets superseded/duplicate rules stay in [suzaku-rules](https://github.com/Yamato-Security/suzaku-rules) for reference while not being loaded (avoiding duplicate detections).

## Behavior

- On timeline load, reads `<rules-dir>/config/<log>_ignore_rule_list.txt` — for AWS that's `./rules/config/aws_ignore_rule_list.txt` (Azure would use `azure_ignore_rule_list.txt`).
- Any loaded rule whose `id` matches a UUID in the file is **skipped**.
- File format (same as the existing `filtered_sigma_rules.txt`): one UUID per line; blank lines and lines starting with `#` are ignored; an inline `# comment` after the UUID is allowed.
- Prints `Rules skipped via ignore-list: N`. No-op when the file is absent.

## Implementation

- `src/core/rules.rs`: `ignore_rule_list_path()`, `load_ignore_rule_ids()`, `filter_ignored_rules()` (+ unit tests).
- `src/core/log_source.rs`: `ignore_rule_list_filename()` per log source.
- `src/core/timeline.rs`: filter loaded rules through the ignore-list before the level filter; report the skipped count.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass (5 new unit tests).
- End-to-end with `aws-ct-timeline` against a rules dir containing `config/aws_ignore_rule_list.txt` (16 UUIDs): output shows `Rules skipped via ignore-list: 16`, and the listed rules no longer appear in the timeline — verified a superseded plain rule (`2070cb71-…`, *IAM Login Profile Created*) is gone while the replacement rules still fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)