### PR TITLE
Add -l/--localtime option to aws-ct-timeline and azure-timeline

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,6 +10,7 @@
 
 **改善:**
 
+- `aws-ct-timeline` および `azure-timeline` コマンドに、イベントのタイムスタンプを（UTC ではなく）実行環境のローカルタイムゾーンで明示的な UTC オフセット付きで出力する `-l, --localtime` オプションを追加した（例: JST では `2023-07-10 12:27:45` が `2023-07-10 21:27:45+09:00` になる）。解析できないタイムスタンプは従来どおり UTC 表記にフォールバックする。 (#34) (@YamatoSecurity)
 - `sigma-rust` をリリース版の `v0.7.1` に更新し、その他の依存クレートもすべて最新版に更新した。`sigma-rust` v0.7.1 は suzaku が利用している Sigma の相関（correlation）機能を維持したまま、YAML バックエンドを非推奨の `serde_yml`/`noyalib`（ルールやイベント中の64ビット符号なし整数の大きな値を精度の落ちた浮動小数点として解析していた）から、活発にメンテナンスされている `yaml_serde` に移行し、`u64` の正しい解析を回復した。 (@YamatoSecurity)
 - `azure-timeline` が SigmaHQ の Microsoft 365 ルールを読み込み・マッチできるようにした。これらのルールは `logsource.service` を `audit`/`exchange`/`threat_detection`/`threat_management` として宣言しているが、従来は `m365` しか認識されず、アップストリームの m365 ルールがすべて読み込み時に破棄されていた。これらのサービスを `m365` と同じ Unified Audit Log の判別（`Workload`/`RecordType`）で振り分けるようにした。 (#137) (@YamatoSecurity)
 - 異なるログソースの取り扱いを容易にするため、コードをリファクタリングした。 (@fukusuket)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Enhancements:**
 
+- Added a `-l, --localtime` option to the `aws-ct-timeline` and `azure-timeline` commands that outputs event timestamps in the machine's local timezone with an explicit UTC offset (e.g. `2023-07-10 12:27:45` becomes `2023-07-10 21:27:45+09:00` in JST) instead of UTC. Unparseable timestamps fall back to the existing UTC rendering. (#34) (@YamatoSecurity)
 - Bumped `sigma-rust` to the released `v0.7.1` and updated all other dependencies to their latest versions. `sigma-rust` v0.7.1 keeps the Sigma correlation support suzaku relies on while moving its YAML backend off the deprecated `serde_yml`/`noyalib` (which parsed large unsigned 64-bit values in rules/events as lossy floats) to the actively maintained `yaml_serde`, restoring correct `u64` parsing. (@YamatoSecurity)
 - Code refactored for easier handling of different log sources. (@fukusuket)
 - Added support for Microsoft Graph API JSON format for Azure logs. (#113) (@fukusuket)

--- a/src/cmd/aws/aws_search.rs
+++ b/src/cmd/aws/aws_search.rs
@@ -38,7 +38,7 @@ pub fn aws_search(options: &SearchOptions, common_opt: &CommonOptions) {
         options.output_opt.output.as_ref(),
         options.output_opt.output_type,
     );
-    let config = OutputConfig::new(no_color, options.output_opt.raw_output);
+    let config = OutputConfig::new(no_color, options.output_opt.raw_output, false);
     let mut context =
         OutputContext::new(&profile, &mut geo_search, &config, writers, &output_pathes);
 

--- a/src/core/timeline.rs
+++ b/src/core/timeline.rs
@@ -118,7 +118,7 @@ pub fn make_timeline(options: &TimelineOptions, common_opt: &CommonOptions, log:
         options.output_opt.output.as_ref(),
         options.output_opt.output_type,
     );
-    let config = OutputConfig::new(no_color, options.output_opt.raw_output);
+    let config = OutputConfig::new(no_color, options.output_opt.raw_output, options.localtime);
     let mut context =
         OutputContext::new(&profile, &mut geo_search, &config, writers, &output_pathes);
     let mut summary = DetectionSummary::default();

--- a/src/core/timeline_writer.rs
+++ b/src/core/timeline_writer.rs
@@ -2,6 +2,7 @@ use crate::core::color::SuzakuColor;
 use crate::core::color::SuzakuColor::{Green, Orange, Red, White, Yellow};
 use crate::core::util::{get_json_writer, get_writer};
 use crate::option::geoip::GeoIPSearch;
+use chrono::{DateTime, Local, NaiveDateTime, TimeZone, Utc};
 use csv::Writer;
 use itertools::Itertools;
 use serde_json::Value;
@@ -15,6 +16,35 @@ use termcolor::{BufferWriter, ColorChoice, ColorSpec, WriteColor};
 pub struct OutputConfig {
     pub no_color: bool,
     pub raw_output: bool,
+    pub localtime: bool,
+}
+
+/// Formats an event timestamp for output.
+///
+/// By default the value is shown in UTC (`T`/`Z` stripped, e.g. `2023-07-10 12:27:45`). When
+/// `localtime` is set, the timestamp is parsed (RFC 3339, or a naive datetime assumed to be UTC)
+/// and rendered in the local timezone with an explicit offset, e.g. `2023-07-10 21:27:45+09:00`.
+/// Unparseable values fall back to the UTC rendering so nothing is dropped.
+fn format_timestamp(value: &str, localtime: bool) -> String {
+    if !localtime {
+        return value.replace("T", " ").replace("Z", "");
+    }
+    let utc: Option<DateTime<Utc>> = DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .ok()
+        .or_else(|| {
+            NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f")
+                .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S"))
+                .ok()
+                .map(|ndt| Utc.from_utc_datetime(&ndt))
+        });
+    match utc {
+        Some(u) => u
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M:%S%:z")
+            .to_string(),
+        None => value.replace("T", " ").replace("Z", ""),
+    }
 }
 
 pub struct Writers {
@@ -35,10 +65,11 @@ pub struct OutputContext<'a> {
 }
 
 pub fn write_record(event: &Event, json: &Value, rule: Option<&Rule>, context: &mut OutputContext) {
+    let localtime = context.config.localtime;
     let mut record: Vec<String> = context
         .profile
         .iter()
-        .map(|(_k, v)| get_value_from_event(v, event, rule, context.geo))
+        .map(|(_k, v)| get_value_from_event(v, event, rule, context.geo, localtime))
         .collect();
     write_to_stdout(&mut record, context, json, Some(event), rule);
     write_to_csv(&record, context);
@@ -84,6 +115,7 @@ fn write_to_stdout(
             buf.set_color(ColorSpec::new().set_fg(color.rdg(context.config.no_color)))
                 .ok();
             let profile = context.profile;
+            let localtime = context.config.localtime;
             let geo = &mut context.geo;
             let mut json_record = json.clone();
             let sigma_profile: Vec<(String, String)> = profile
@@ -94,7 +126,7 @@ fn write_to_stdout(
 
             for (k, v) in sigma_profile {
                 if let (Some(event), rule) = (event, rule) {
-                    let value = get_value_from_event(&v, event, rule, geo);
+                    let value = get_value_from_event(&v, event, rule, geo, localtime);
                     json_record[k] = Value::String(value.to_string());
                 }
             }
@@ -143,6 +175,7 @@ fn write_to_json_format(
 
     if raw_output {
         let profile = context.profile;
+        let localtime = context.config.localtime;
         let geo = &mut context.geo;
 
         let writer = if pretty {
@@ -161,7 +194,7 @@ fn write_to_json_format(
 
             for (k, v) in sigma_profile {
                 if let (Some(event), rule) = (event, rule) {
-                    let value = get_value_from_event(&v, event, rule, geo);
+                    let value = get_value_from_event(&v, event, rule, geo, localtime);
                     json_record[k] = Value::String(value.to_string());
                 }
             }
@@ -250,6 +283,7 @@ fn build_correlation_record(
 ) -> Vec<String> {
     let events: Vec<Event> = events.iter().map(|e| e.event.clone()).collect();
     let profile = &context.profile;
+    let localtime = context.config.localtime;
     let mut correlation_map: HashMap<String, String> = HashMap::new();
     for (_, profile_value) in profile.iter() {
         let mut values = HashSet::new();
@@ -257,7 +291,13 @@ fn build_correlation_record(
             if profile_value == ".eventTime" && i < events.len() - 1 {
                 continue;
             }
-            let value = get_value_from_correlation_event(profile_value, event, rule, context.geo);
+            let value = get_value_from_correlation_event(
+                profile_value,
+                event,
+                rule,
+                context.geo,
+                localtime,
+            );
             values.insert(value);
         }
         let values: Vec<String> = values.into_iter().sorted().collect();
@@ -280,6 +320,7 @@ fn get_value_from_event_common(
     event: &Event,
     rule_info: RuleInfo,
     geo_ip: &mut Option<GeoIPSearch>,
+    localtime: bool,
 ) -> String {
     // GeoIP処理部分（共通）
     if let Some(geo) = geo_ip
@@ -310,7 +351,7 @@ fn get_value_from_event_common(
                     || k_trimmed.contains("eventTimestamp")
                     || k_trimmed.contains("CreationTime")
                 {
-                    value.value_to_string().replace("T", " ").replace("Z", "")
+                    format_timestamp(&value.value_to_string(), localtime)
                 } else {
                     value.value_to_string()
                 };
@@ -437,8 +478,15 @@ fn get_value_from_correlation_event(
     event: &Event,
     rule: &SigmaCorrelationRule,
     geo_ip: &mut Option<GeoIPSearch>,
+    localtime: bool,
 ) -> String {
-    get_value_from_event_common(key, event, RuleInfo::CorrelationRule(rule), geo_ip)
+    get_value_from_event_common(
+        key,
+        event,
+        RuleInfo::CorrelationRule(rule),
+        geo_ip,
+        localtime,
+    )
 }
 
 fn get_value_from_event(
@@ -446,9 +494,10 @@ fn get_value_from_event(
     event: &Event,
     rule: Option<&Rule>,
     geo_ip: &mut Option<GeoIPSearch>,
+    localtime: bool,
 ) -> String {
     if let Some(rule) = rule {
-        get_value_from_event_common(key, event, RuleInfo::Rule(rule), geo_ip)
+        get_value_from_event_common(key, event, RuleInfo::Rule(rule), geo_ip, localtime)
     } else {
         "".to_string()
     }
@@ -456,10 +505,11 @@ fn get_value_from_event(
 
 // 使用例
 impl OutputConfig {
-    pub fn new(no_color: bool, raw_output: bool) -> Self {
+    pub fn new(no_color: bool, raw_output: bool, localtime: bool) -> Self {
         Self {
             no_color,
             raw_output,
+            localtime,
         }
     }
 }
@@ -622,4 +672,48 @@ pub fn init_writers(output_path: Option<&PathBuf>, output_type: u8) -> (Writers,
     }
 
     (writers, output_pathes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_timestamp_utc_default_strips_t_and_z() {
+        assert_eq!(
+            format_timestamp("2023-07-10T12:27:45Z", false),
+            "2023-07-10 12:27:45"
+        );
+    }
+
+    #[test]
+    fn format_timestamp_localtime_preserves_rfc3339_instant() {
+        // The localtime rendering carries an explicit offset, so re-parsing it must
+        // recover the same UTC instant regardless of the machine's local timezone.
+        let out = format_timestamp("2023-07-10T12:27:45Z", true);
+        let parsed = DateTime::parse_from_str(&out, "%Y-%m-%d %H:%M:%S%:z")
+            .expect("localtime output should be parseable with an offset");
+        assert_eq!(
+            parsed.with_timezone(&Utc),
+            Utc.with_ymd_and_hms(2023, 7, 10, 12, 27, 45).unwrap()
+        );
+    }
+
+    #[test]
+    fn format_timestamp_localtime_assumes_naive_is_utc() {
+        // A naive timestamp (no offset, e.g. M365 CreationTime) is treated as UTC.
+        let out = format_timestamp("2023-07-10T12:27:45", true);
+        let parsed = DateTime::parse_from_str(&out, "%Y-%m-%d %H:%M:%S%:z")
+            .expect("localtime output should be parseable with an offset");
+        assert_eq!(
+            parsed.with_timezone(&Utc),
+            Utc.with_ymd_and_hms(2023, 7, 10, 12, 27, 45).unwrap()
+        );
+    }
+
+    #[test]
+    fn format_timestamp_localtime_falls_back_on_unparseable() {
+        // Non-timestamp values must not be dropped; fall back to the UTC rendering.
+        assert_eq!(format_timestamp("not-a-timestamp", true), "not-a-timestamp");
+    }
 }

--- a/src/option/cli.rs
+++ b/src/option/cli.rs
@@ -165,6 +165,10 @@ pub struct TimelineOptions {
     /// Minimum level for rules to load (default: informational)
     #[arg(help_heading = Some("Output"), short = 'm', long = "min-level", default_value = "informational", hide_default_value = true, value_name = "LEVEL", display_order = 302)]
     pub min_level: String,
+
+    /// Output the timestamp in the local timezone (default: UTC)
+    #[arg(help_heading = Some("Time Format"), short = 'l', long = "localtime", display_order = 351)]
+    pub localtime: bool,
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
## Summary

Closes #34.

Adds a `-l, --localtime` option that outputs event timestamps in the machine's local timezone with an explicit UTC offset, instead of the default UTC. The issue requested it for `aws-ct-timeline`; as requested it is also wired into `azure-timeline` (both subcommands share the same `TimelineOptions`, so a single flag covers both).

### Behavior

| | Timestamp output |
|---|---|
| default (UTC) | `2023-07-10 12:27:45` |
| `--localtime` (in JST) | `2023-07-10 21:27:45+09:00` |

- RFC 3339 timestamps (`...Z` / `...+00:00`, with or without fractional seconds) are parsed and converted.
- Naive, offset-less timestamps (e.g. M365 `CreationTime` like `2023-07-10T12:27:45`) are assumed to be UTC before conversion.
- Anything unparseable falls back to the existing UTC (`T`/`Z`-stripped) rendering, so no value is ever dropped.
- Applies across all output sinks (stdout, CSV, JSON, JSONL). The `aws-ct-search` command is unaffected (passes `false`).

### Implementation

- New `localtime: bool` on `TimelineOptions` (`src/option/cli.rs`), under a **Time Format** help heading.
- New `format_timestamp(value, localtime)` helper centralizes the formatting that was previously an inline `.replace("T", " ").replace("Z", "")` in `get_value_from_event_common`; `localtime` is threaded through `OutputConfig` → `get_value_from_event` / `get_value_from_correlation_event`.

### Testing

- Added 4 unit tests for `format_timestamp`. The conversion tests re-parse the emitted offset and compare the recovered instant, so they are deterministic regardless of the CI runner's timezone.
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check`, and `cargo test` (91 + 4 tests) all pass.
- Verified end-to-end against `test_files/json` under `TZ=Asia/Tokyo`: `2024-08-18 13:05:25` (UTC) → `2024-08-18 22:05:25+09:00` (`--localtime`) in both stdout and CSV output.