### PR TITLE
docs: sync aws-ct-timeline output profile block with the real config

### DIFF
--- a/website/docs/commands/dfir-timeline.ar.md
+++ b/website/docs/commands/dfir-timeline.ar.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### ملف تعريف الإخراج لـ `aws-ct-timeline`
 
-سيقوم Suzaku بإخراج المعلومات استنادًا إلى ملف `config/default_profile.yaml`:
+سيقوم Suzaku بإخراج المعلومات استنادًا إلى ملف `config/aws_profile.yaml`:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.de.md
+++ b/website/docs/commands/dfir-timeline.de.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline`-Ausgabeprofil
 
-Suzaku gibt Informationen basierend auf der Datei `config/default_profile.yaml` aus:
+Suzaku gibt Informationen basierend auf der Datei `config/aws_profile.yaml` aus:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.es.md
+++ b/website/docs/commands/dfir-timeline.es.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### Perfil de salida de `aws-ct-timeline`
 
-Suzaku mostrará la información basándose en el archivo `config/default_profile.yaml`:
+Suzaku mostrará la información basándose en el archivo `config/aws_profile.yaml`:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.fr.md
+++ b/website/docs/commands/dfir-timeline.fr.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### Profil de sortie de `aws-ct-timeline`
 
-Suzaku affichera les informations en fonction du fichier `config/default_profile.yaml` :
+Suzaku affichera les informations en fonction du fichier `config/aws_profile.yaml` :
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.hi.md
+++ b/website/docs/commands/dfir-timeline.hi.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline` आउटपुट प्रोफ़ाइल
 
-Suzaku `config/default_profile.yaml` फ़ाइल के आधार पर जानकारी आउटपुट करेगा:
+Suzaku `config/aws_profile.yaml` फ़ाइल के आधार पर जानकारी आउटपुट करेगा:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.id.md
+++ b/website/docs/commands/dfir-timeline.id.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### Profil output `aws-ct-timeline`
 
-Suzaku akan menampilkan informasi berdasarkan file `config/default_profile.yaml`:
+Suzaku akan menampilkan informasi berdasarkan file `config/aws_profile.yaml`:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.ja.md
+++ b/website/docs/commands/dfir-timeline.ja.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline`出力プロフィール
 
-Suzakuは`config/default_profile.yaml`ファイルに基づいて情報を出力します:
+Suzakuは`config/aws_profile.yaml`ファイルに基づいて情報を出力します:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.ko.md
+++ b/website/docs/commands/dfir-timeline.ko.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline` 출력 프로파일
 
-Suzaku는 `config/default_profile.yaml` 파일을 기반으로 정보를 출력합니다:
+Suzaku는 `config/aws_profile.yaml` 파일을 기반으로 정보를 출력합니다:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.md
+++ b/website/docs/commands/dfir-timeline.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline` output profile
 
-Suzaku will output information based on the `config/default_profile.yaml` file:
+Suzaku will output information based on the `config/aws_profile.yaml` file:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.my.md
+++ b/website/docs/commands/dfir-timeline.my.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline` output profile
 
-Suzaku သည် `config/default_profile.yaml` ဖိုင်ကို အခြေခံ၍ အချက်အလက်များကို ထုတ်ပေးပါမည်:
+Suzaku သည် `config/aws_profile.yaml` ဖိုင်ကို အခြေခံ၍ အချက်အလက်များကို ထုတ်ပေးပါမည်:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.pt-BR.md
+++ b/website/docs/commands/dfir-timeline.pt-BR.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### Perfil de saída do `aws-ct-timeline`
 
-O Suzaku exibirá as informações com base no arquivo `config/default_profile.yaml`:
+O Suzaku exibirá as informações com base no arquivo `config/aws_profile.yaml`:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.th.md
+++ b/website/docs/commands/dfir-timeline.th.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### โปรไฟล์ผลลัพธ์ของ `aws-ct-timeline`
 
-Suzaku จะแสดงผลข้อมูลตามไฟล์ `config/default_profile.yaml`:
+Suzaku จะแสดงผลข้อมูลตามไฟล์ `config/aws_profile.yaml`:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.tr.md
+++ b/website/docs/commands/dfir-timeline.tr.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline` çıktı profili
 
-Suzaku, bilgileri `config/default_profile.yaml` dosyasına göre çıktılar:
+Suzaku, bilgileri `config/aws_profile.yaml` dosyasına göre çıktılar:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.uk.md
+++ b/website/docs/commands/dfir-timeline.uk.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### Профіль виводу команди `aws-ct-timeline`
 
-Suzaku виводить інформацію на основі файлу `config/default_profile.yaml`:
+Suzaku виводить інформацію на основі файлу `config/aws_profile.yaml`:
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 

--- a/website/docs/commands/dfir-timeline.zh-TW.md
+++ b/website/docs/commands/dfir-timeline.zh-TW.md
@@ -45,13 +45,15 @@ Display Settings:
 
 ### `aws-ct-timeline` 輸出設定檔
 
-Suzaku 會根據 `config/default_profile.yaml` 檔案輸出資訊：
+Suzaku 會根據 `config/aws_profile.yaml` 檔案輸出資訊：
 ```yaml
 Timestamp: '.eventTime'
 RuleTitle: 'sigma.title'
 RuleAuthor: 'sigma.author'
 Level: 'sigma.level'
 EventName: '.eventName'
+ErrorCode: '.errorCode'
+ErrorMessage: '.errorMessage'
 EventSource: '.eventSource'
 AWS-Region: '.awsRegion'
 SrcIP: '.sourceIPAddress'
@@ -63,6 +65,7 @@ UserARN: '.userIdentity.arn'
 UserPrincipalID: '.userIdentity.principalId'
 UserAccessKeyID: '.userIdentity.accessKeyId'
 EventID: '.eventID'
+Tags: 'sigma.tags'
 RuleID: 'sigma.id'
 ```
 


### PR DESCRIPTION
## Summary

Cleanup of pre-existing documentation drift flagged during the #62 review.

The `aws-ct-timeline` **output profile** section in the DFIR timeline docs hand-copies the profile as a YAML block. That block (duplicated verbatim across all **15 localized copies** of `dfir-timeline*.md`) had drifted from the real `config/aws_profile.yaml`:

- It referenced **`config/default_profile.yaml`, which does not exist** — the `aws-ct-timeline` profile is `config/aws_profile.yaml`.
- It omitted the **`ErrorCode`** and **`ErrorMessage`** columns (added to the profile in an earlier release).
- It omitted the **`Tags`** column (added in #62 / #142).

This PR syncs the documented block to the real profile in all 15 files. Each file is a clean +4/−1 change; only the filename token and the YAML block change — translated prose is untouched.

## Notes

- Docs-only change; no code, no build/test impact (mkdocs still builds).
- The `Tags: 'sigma.tags'` line corresponds to the config change in **#62 (PR #142)**. There is no file overlap between the two PRs (#142 touches `config/`+`src/`, this touches `website/docs/`), so they can merge in either order; ideally merge this **after** #142 so the documented column exists in the shipped config.
- `azure-timeline` has no output-profile section in the docs, so nothing to change there.