### PR TITLE
ci: cut the Windows CI job time by removing a duplicate full build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,13 @@
 name: Rust
 
 on:
+  # A run triggered by `pull_request` saves its cache under that PR's own scope, which
+  # no other PR can read. Only caches written on the default branch are restorable by
+  # every PR, so without this `push` trigger there is never a warm cache to restore and
+  # each PR pays a full cold build of the bundled DuckDB C++ engine.
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
           targets: ${{ matrix.info.target }}
       - name: Enable Rust cache
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f #2.1.0
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Fmt Check
         run: cargo fmt -- --check
       - name: Prepare Clippy
@@ -80,7 +80,12 @@ jobs:
           RUST_BACKTRACE: full
           OPENSSL_STATIC: "1"
           PKG_CONFIG_ALLOW_CROSS: "1"
+      # `--target` must match the "Build tests" step above. Cargo puts artifacts in
+      # `target/<triple>/debug` when `--target` is passed and in `target/debug` when it
+      # is not, even where host == target, so omitting it here made this step rebuild
+      # the entire dependency tree from scratch — including the bundled DuckDB C++
+      # engine — instead of reusing what "Build tests" just built.
       - name: Run tests
         env:
           RUST_TEST_THREADS: 1
-        run: cargo test --verbose
+        run: cargo test --verbose --target=${{ matrix.info.target }}


### PR DESCRIPTION
## Problem

The Windows CI job takes **30–44 minutes** per run. It used to take about 6 minutes; the jump happened when `duckdb = { features = ["bundled"] }` landed, since that compiles the whole DuckDB C++ engine from source.

That much is unavoidable — but we were paying for it **twice per run**, and never caching the result.

## Cause 1: `Build tests` and `Run tests` used different target directories

- `Build tests`: `cargo test --no-run --locked --target=x86_64-pc-windows-msvc` → `target\x86_64-pc-windows-msvc\debug\`
- `Run tests`: `cargo test --verbose` (no `--target`) → `target\debug\`

Cargo separates these directories whenever `--target` is passed, even when host == target, so the second step could not reuse anything the first one built. The job log confirmed it recompiling the bundled DuckDB engine:

```
Run tests  Compiling libduckdb-sys ...
           --out-dir D:\a\suzaku\suzaku\target\debug\build\libduckdb-sys-8cf4e2ff39d043ba
```

**Fix:** pass the same `--target` in `Run tests`.

## Cause 2: the cache was never restored, and had started failing to save

`Enable Rust cache` finished in 1–2 seconds (nothing restored) while the save step spent 4 minutes each run. Two reasons:

1. **Cache scoping.** The workflow only triggered on `pull_request`, so every cache it wrote landed in that PR's own scope, which no other PR can read. Only caches written on the default branch are restorable by all PRs. Added a `push` trigger for `main`.
2. **Action version.** `Swatinem/rust-cache` was pinned at 2.1.0 (Oct 2022), predating the Actions cache service v2 migration. Its save step had started failing outright with `Failed to save: <h2>Our services aren't available right now</h2>`. Bumped to v2.9.1.

## Measured result

Comparing [run 30189419005](https://github.com/Yamato-Security/suzaku/actions/runs/30189419005) (before) with [run 30190573397](https://github.com/Yamato-Security/suzaku/actions/runs/30190573397) (this PR):

| Step | Before | After |
|---|---|---|
| Run clippy | 7 m 56 s | 9 m 19 s |
| Build tests | 9 m 48 s | 10 m 26 s |
| **Run tests** | **8 m 56 s** | **5 s** |
| Post cache (save) | 4 m 08 s (failed) | 3 m 46 s (2.1 GB saved OK) |
| **Total job** | **31 m** | **24 m** |

`Run tests` now reports every dependency as `Fresh` with **zero** `Compiling` lines, and the suite still runs for real:

```
running 134 tests
test result: ok. 134 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.35s
```

The cache also saved successfully for the first time (2.1 GB). clippy and `Build tests` are ~1 min slower here purely from runner variance — they are untouched by this change, and are what the restored cache should shrink from the next PR onward.

## Notes for review

Two commits, separable:

- `5561f3c` — `--target` fix + rust-cache bump. No policy implications.
- `f36170f` — `push: branches: [main]` trigger. **This one is a usage tradeoff**: it adds one run of the (single, Windows-only) matrix entry per merge to main. Given the matrix was deliberately trimmed to cut Actions usage, please drop this commit if you would rather not pay that. Note the rust-cache bump alone will not produce cache hits across PRs without it.