### PR TITLE
ci: build clippy into the same target dir as the tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,10 +63,12 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Fmt Check
         run: cargo fmt -- --check
-      - name: Prepare Clippy
-        run: rustup component add clippy
+      # `--target` must match the "Build tests"/"Run tests" steps below. Without it clippy
+      # builds into `target/debug` while those build into `target/<triple>/debug`, so the
+      # bundled DuckDB C++ engine gets compiled once per directory and the cache ends up
+      # holding two full copies of every artifact.
       - name: Run clippy action to produce annotations
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --target=${{ matrix.info.target }} -- -D warnings
       - name: Install dependencies for musl
         if: matrix.info.os == 'ubuntu-latest' && matrix.info.cross == true
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Enable Rust cache
         if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Bumped from the implicit v0 to discard the existing ~2.1 GB cache, which was
+          # written under the old layout where clippy and the tests used separate target
+          # directories and every artifact was stored twice. rust-cache skips saving on a
+          # full key match ("Cache up-to-date"), so without a new prefix the stale cache
+          # would survive until Cargo.lock or the toolchain changed. Costs one cold run.
+          prefix-key: v1-rust
       - name: Fmt Check
         run: cargo fmt -- --check
       # `--target` must match the "Build tests"/"Run tests" steps below. Without it clippy


### PR DESCRIPTION
Follow-up to #178. Same class of problem, one step earlier in the job.

## Cause

`cargo clippy --all-targets` had no `--target`, so it built into `target/debug`, while `Build tests` and `Run tests` pass `--target=x86_64-pc-windows-msvc` and build into `target/x86_64-pc-windows-msvc/debug`. Two consequences:

1. On a cold run the bundled DuckDB C++ engine was built once per directory.
2. rust-cache caches the whole `target` directory, so the saved cache held two full copies of every artifact — 2.1 GB. After #178, restoring it had become the largest single step in a warm run: 1 m 11 s of a 2 m 57 s job ([30205720610](https://github.com/Yamato-Security/suzaku/actions/runs/30205720610)).

## Fix

Pass the same `--target` to clippy, so everything lands in one directory and the DuckDB build-script output is shared.

This also makes clippy check the same configuration the build actually uses: `.cargo/config.toml` sets its `crt-static` rustflags under a `[target.'cfg(...)']` key, and Cargo applies those to build scripts and proc macros only when `--target` is absent — which was true for clippy but not for the steps that build the binary.

Also dropped the `Prepare Clippy` step (`rustup component add clippy`); `Set up Rust toolchain` directly above already installs it via `components: rustfmt, clippy`.

## Measured: cold run

Before ([30190573397](https://github.com/Yamato-Security/suzaku/actions/runs/30190573397)) vs after ([30262600865](https://github.com/Yamato-Security/suzaku/actions/runs/30262600865)):

| Step | Before | After |
|---|---|---|
| Run clippy | 9 m 19 s | 10 m 41 s |
| **Build tests** | **10 m 26 s** | **2 m 15 s** |
| Run tests | 5 s | 4 s |
| Post cache (save) | 3 m 46 s | 3 m 50 s |
| **Total job** | **24 m 17 s** | **17 m 42 s** |

`Compiling libduckdb-sys` still appears in both steps, because clippy builds dependencies in check mode and `Build tests` still needs codegen for them. What is no longer repeated is the expensive part — the build script's compilation of the DuckDB C++ engine, whose output is now shared through the common target directory. That is what takes `Build tests` from 10 m 26 s to 2 m 15 s.

clippy is ~1 min slower, since it now carries the build-script work the second step used to redo, plus runner variance.

## Measured: cache size

| | Bytes | |
|---|---|---|
| Before | 2,192,222,668 | 2.19 GB |
| After | 1,464,423,691 | 1.46 GB |

**33% smaller.** Less than the halving I first estimated: the cache also holds `~/.cargo/registry` and `~/.cargo/git`, which this change does not affect — only the duplicated `target` portion collapses.

Scaling the 1 m 11 s restore by that ratio projects roughly **45-50 s**, i.e. a warm run of about 2 m 30 s rather than 2 m 57 s. That figure is a projection, not a measurement; the first warm run after merge will confirm it.

Tests are unaffected: `137 passed; 0 failed` on both runs. Locally, `cargo clippy --all-targets --target=aarch64-apple-darwin -- -D warnings` passes with no warnings.

## Second commit: why the prefix-key bump is needed

The first run on this branch ([30262241773](https://github.com/Yamato-Security/suzaku/actions/runs/30262241773)) restored the existing cache with a full key match and skipped saving:

```
Cache hit for: v0-rust-build-Windows_NT-x64-8af1e26a-1e2fa759
Cache Size: ~2091 MB
Restored from cache key "..." full match: true.
...
Post Enable Rust cache:  Cache up-to-date.
```

Since rust-cache only writes when the key misses, the new single-directory layout would have sat unsaved until `Cargo.lock` or the toolchain happened to change, and the 2.1 GB entry would have survived. `87f7bf0` bumps `prefix-key` to `v1-rust` to discard it once and force a save under the new layout — the 17 m 42 s run above is that cold run, and the 1.46 GB is what it saved.