### PR TITLE
test: make the #159 GeoIP regression test able to fail

### DIFF
--- a/src/core/timeline_writer.rs
+++ b/src/core/timeline_writer.rs
@@ -1455,6 +1455,202 @@ mod tests {
         );
     }
 
+    /// Drives the real `write_record` path -- the shipped profile from `load_profile`, the
+    /// profile-derived `SrcIP` spec, the CSV writer -- and returns the emitted row as a map.
+    ///
+    /// The point is to bind the profile to the enrichment. `geoip_resolves_source_ip_via_profile_spec`
+    /// passes literal specs straight to `get_value_from_event`, so hardcoding a field name back
+    /// into `write_record` (which is where #159 actually lived) would leave every assertion there
+    /// green. Verified by mutation: replacing `src_ip_spec(context.profile)` at the top of
+    /// `write_record` with a literal `".sourceIPAddress"` fails this test and nothing else in the
+    /// suite.
+    fn write_record_columns(
+        log: &crate::core::log_source::LogSource,
+        event_json: &str,
+        geo: &mut Option<crate::option::geoip::GeoIPSearch>,
+    ) -> std::collections::HashMap<String, String> {
+        use crate::core::util::load_profile;
+        use sigma_rust::{event_from_json, rule_from_yaml};
+
+        let profile = load_profile(log, geo, true);
+        let rule = rule_from_yaml(
+            "title: t\nlogsource:\n    category: test\ndetection:\n    selection:\n        eventName: E\n    condition: selection\n",
+        )
+        .unwrap();
+        let event = event_from_json(event_json).unwrap();
+        let json: Value = serde_json::from_str(event_json).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let csv_path = dir.path().join("out.csv");
+        let config = OutputConfig::new(true, false, false);
+        {
+            let file = std::fs::File::create(&csv_path).unwrap();
+            let writers = Writers::new()
+                .with_csv(csv::WriterBuilder::new().from_writer(Box::new(file) as Box<dyn Write>));
+            let mut context = OutputContext::new(&profile, geo, &config, writers, &[]);
+            write_record(&event, &json, Some(&rule), &mut context);
+            context.flush_all();
+        }
+
+        let text = std::fs::read_to_string(&csv_path).unwrap();
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader(text.as_bytes());
+        let row: Vec<String> = reader
+            .records()
+            .next()
+            .expect("write_record emitted no CSV row")
+            .unwrap()
+            .iter()
+            .map(|f| f.to_string())
+            .collect();
+        profile.iter().map(|(k, _)| k.clone()).zip(row).collect()
+    }
+
+    // #159 must stay fixed at the level it actually broke: the profile. The test above pins the
+    // resolution given a spec; this one pins that the shipped Azure/M365 profile is what supplies
+    // that spec, end to end through `write_record`.
+    #[test]
+    fn write_record_enriches_geoip_from_the_shipped_profile() {
+        use crate::core::log_source::LogSource;
+        use crate::option::geoip::GeoIPSearch;
+        use std::path::Path;
+
+        let mut geo = Some(
+            GeoIPSearch::new(Path::new("test_files/mmdb"))
+                .expect("GeoLite2 test .mmdb files must be present under test_files/mmdb/"),
+        );
+
+        // Azure: the caller IP lives in `callerIpAddress`, a field name that does not exist in
+        // CloudTrail. This is the exact record shape #159 reported as always rendering "-".
+        let azure = write_record_columns(
+            &LogSource::Azure,
+            r#"{"callerIpAddress": "89.160.20.112", "eventName": "E", "operationName": "op"}"#,
+            &mut geo,
+        );
+        assert_eq!(
+            azure.get("SrcIP").map(String::as_str),
+            Some("89.160.20.112")
+        );
+        assert_eq!(
+            azure.get("SrcASN").map(String::as_str),
+            Some("Bredband2 AB")
+        );
+        assert_eq!(azure.get("SrcCity").map(String::as_str), Some("Linköping"));
+        assert_eq!(azure.get("SrcCountry").map(String::as_str), Some("Sweden"));
+
+        // AWS through the same path, so a regression that breaks one log source and not the other
+        // is still caught.
+        let aws = write_record_columns(
+            &LogSource::Aws,
+            r#"{"sourceIPAddress": "89.160.20.112", "eventName": "E"}"#,
+            &mut geo,
+        );
+        assert_eq!(aws.get("SrcASN").map(String::as_str), Some("Bredband2 AB"));
+        assert_eq!(aws.get("SrcCountry").map(String::as_str), Some("Sweden"));
+    }
+
+    /// The correlation sibling of `write_record_columns`: drives `write_correlation_record`,
+    /// which builds its row through `get_value_from_correlation_event` and computes the spec at a
+    /// *different* call site (`build_correlation_record`). A hardcode there would be invisible to
+    /// the non-correlation tests.
+    fn write_correlation_columns(
+        log: &crate::core::log_source::LogSource,
+        event_json: &str,
+        geo: &mut Option<crate::option::geoip::GeoIPSearch>,
+    ) -> std::collections::HashMap<String, String> {
+        use crate::core::util::load_profile;
+        use sigma_rust::{SigmaCorrelationRule, TimestampedEvent, event_from_json, rule_from_yaml};
+
+        let profile = load_profile(log, geo, true);
+        let base_rule = rule_from_yaml(
+            "title: t\nlogsource:\n    category: test\ndetection:\n    selection:\n        eventName: E\n    condition: selection\n",
+        )
+        .unwrap();
+        let correlation_rule = SigmaCorrelationRule {
+            title: "c".to_string(),
+            ..Default::default()
+        };
+        let timestamped = TimestampedEvent {
+            event: event_from_json(event_json).unwrap(),
+            timestamp: "2024-01-01T00:00:00Z".parse().unwrap(),
+            rule: &base_rule,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let csv_path = dir.path().join("out.csv");
+        let config = OutputConfig::new(true, false, false);
+        {
+            let file = std::fs::File::create(&csv_path).unwrap();
+            let writers = Writers::new()
+                .with_csv(csv::WriterBuilder::new().from_writer(Box::new(file) as Box<dyn Write>));
+            let mut context = OutputContext::new(&profile, geo, &config, writers, &[]);
+            write_correlation_record(&vec![&timestamped], &correlation_rule, &mut context);
+            context.flush_all();
+        }
+
+        let text = std::fs::read_to_string(&csv_path).unwrap();
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader(text.as_bytes());
+        let row: Vec<String> = reader
+            .records()
+            .next()
+            .expect("write_correlation_record emitted no CSV row")
+            .unwrap()
+            .iter()
+            .map(|f| f.to_string())
+            .collect();
+        profile.iter().map(|(k, _)| k.clone()).zip(row).collect()
+    }
+
+    // Correlation rows go through their own record builder and their own `src_ip_spec` call, so
+    // #159 could regress there alone. Verified by mutation: hardcoding the spec inside
+    // `build_correlation_record` fails this test and nothing else.
+    #[test]
+    fn write_correlation_record_enriches_geoip_from_the_shipped_profile() {
+        use crate::option::geoip::GeoIPSearch;
+        use std::path::Path;
+
+        let mut geo = Some(
+            GeoIPSearch::new(Path::new("test_files/mmdb"))
+                .expect("GeoLite2 test .mmdb files must be present under test_files/mmdb/"),
+        );
+        let azure = write_correlation_columns(
+            &crate::core::log_source::LogSource::Azure,
+            r#"{"callerIpAddress": "89.160.20.112", "eventName": "E", "operationName": "op"}"#,
+            &mut geo,
+        );
+        assert_eq!(
+            azure.get("SrcASN").map(String::as_str),
+            Some("Bredband2 AB")
+        );
+        assert_eq!(azure.get("SrcCountry").map(String::as_str), Some("Sweden"));
+    }
+
+    // Without -G the profile has no geo columns at all, so the enrichment above cannot be an
+    // artifact of columns that are always present.
+    #[test]
+    fn write_record_omits_geo_columns_without_geoip() {
+        use crate::core::log_source::LogSource;
+        let mut geo = None;
+        let azure = write_record_columns(
+            &LogSource::Azure,
+            r#"{"callerIpAddress": "89.160.20.112", "eventName": "E", "operationName": "op"}"#,
+            &mut geo,
+        );
+        assert_eq!(
+            azure.get("SrcIP").map(String::as_str),
+            Some("89.160.20.112")
+        );
+        for key in ["SrcASN", "SrcCity", "SrcCountry"] {
+            assert!(
+                !azure.contains_key(key),
+                "{key} must not be emitted without -G"
+            );
+        }
+    }
+
     /// The full AWS timeline profile, so the schema assertions below run against the real
     /// column set rather than a hand-picked subset.
     fn aws_profile_keys() -> Vec<String> {

--- a/src/core/timeline_writer.rs
+++ b/src/core/timeline_writer.rs
@@ -1376,6 +1376,14 @@ mod tests {
     // spec, so an Azure `callerIpAddress` enriches identically to an AWS
     // `sourceIPAddress`. Before the fix the Azure field was ignored (the lookup
     // hardcoded `sourceIPAddress`) and the geo columns were always "-".
+    //
+    // The IP must be one the checked-in GeoLite2 *test* databases actually contain --
+    // they are MaxMind's small fixtures, not the real feeds, and resolve only a handful
+    // of ranges. 89.160.20.112 is in all three (ASN "Bredband2 AB", city Linköping,
+    // country Sweden). An IP outside them, such as a public resolver address, makes
+    // every branch return "-" and the assertions stop distinguishing the fix from the
+    // bug: verified by mutation that with the hardcoded `event.get("sourceIPAddress")`
+    // restored, this test fails on the Azure lookups below and passed before this change.
     #[test]
     fn geoip_resolves_source_ip_via_profile_spec() {
         use crate::option::geoip::GeoIPSearch;
@@ -1386,7 +1394,8 @@ mod tests {
             "title: t\nlogsource:\n    category: test\ndetection:\n    selection:\n        eventName: E\n    condition: selection\n",
         )
         .unwrap();
-        let ip = "8.8.8.8";
+        // Present in test_files/mmdb for all three databases.
+        let ip = "89.160.20.112";
         let aws_event = event_from_json(&format!(
             r#"{{"sourceIPAddress": "{ip}", "eventName": "E"}}"#
         ))
@@ -1400,28 +1409,50 @@ mod tests {
             GeoIPSearch::new(Path::new("test_files/mmdb"))
                 .expect("GeoLite2 test .mmdb files must be present under test_files/mmdb/"),
         );
-        let aws_country = get_value_from_event(
-            "SrcCountry",
-            &aws_event,
-            Some(&rule),
-            &mut geo,
-            false,
-            ".sourceIPAddress",
+        let lookup = |key: &str, event: &sigma_rust::Event, spec: &str, geo: &mut _| {
+            get_value_from_event(key, event, Some(&rule), geo, false, spec)
+        };
+
+        // The AWS field enriches -- this is the control. If these ever go back to "-" the
+        // test databases have changed and the assertions below would stop meaning anything.
+        assert_eq!(
+            lookup("SrcCountry", &aws_event, ".sourceIPAddress", &mut geo),
+            "Sweden",
+            "the control lookup must enrich; is 89.160.20.112 still in test_files/mmdb?"
         );
-        let azure_country = get_value_from_event(
-            "SrcCountry",
-            &azure_event,
-            Some(&rule),
-            &mut geo,
-            false,
-            ".callerIpAddress",
+
+        // The Azure field must enrich identically, resolved through the profile's spec
+        // rather than a hardcoded AWS field name. Each of the three geo columns is checked
+        // because they are three separate lookups against three separate databases.
+        assert_eq!(
+            lookup("SrcCountry", &azure_event, ".callerIpAddress", &mut geo),
+            "Sweden"
         );
-        // Same IP + same DB must enrich identically regardless of the field name.
-        assert_eq!(aws_country, azure_country);
-        // When the DB actually resolves the IP, the Azure field must enrich (not "-").
-        if aws_country != "-" {
-            assert_ne!(azure_country, "-");
-        }
+        assert_eq!(
+            lookup("SrcASN", &azure_event, ".callerIpAddress", &mut geo),
+            "Bredband2 AB"
+        );
+        assert_eq!(
+            lookup("SrcCity", &azure_event, ".callerIpAddress", &mut geo),
+            "Linköping"
+        );
+
+        // The real Azure/M365 profile declares a `|`-separated fallback list; the field
+        // that is actually present must be found wherever it sits in that list.
+        let azure_spec = ".claims.ipaddr|.callerIpAddress|.ClientIP|.ActorIpAddress";
+        assert_eq!(
+            lookup("SrcCountry", &azure_event, azure_spec, &mut geo),
+            "Sweden",
+            "a later candidate in the SrcIP spec must still be found"
+        );
+
+        // A profile with no SrcIP column, or an event carrying none of the candidates,
+        // yields the placeholder rather than enriching from some unrelated field.
+        assert_eq!(lookup("SrcCountry", &azure_event, "", &mut geo), "-");
+        assert_eq!(
+            lookup("SrcCountry", &aws_event, ".callerIpAddress", &mut geo),
+            "-"
+        );
     }
 
     /// The full AWS timeline profile, so the schema assertions below run against the real


### PR DESCRIPTION
Follow-up to #171 (which fixed #159). **Test-only — no production code changes.**

## The problem

The regression test added alongside the #159 fix passed whether or not the fix was present. I reintroduced the exact bug it guards — resolving the source IP from a hardcoded `event.get("sourceIPAddress")` instead of the profile's `SrcIP` spec — and it stayed green.

Both reasons are about the fixture, not the assertions:

**The IP was not in the test databases.** The test looked up `8.8.8.8`. `test_files/mmdb/` holds MaxMind's small *test* fixtures — about 240 networks — not the real GeoLite2 feeds, and `8.8.8.8` is not among them. So the AWS control and the Azure subject both returned the `-` placeholder and `assert_eq!(aws_country, azure_country)` compared `"-"` with `"-"`.

**The one assertion that could have caught it was guarded.**

```rust
assert_eq!(aws_country, azure_country);   // "-" == "-", passes with the bug
if aws_country != "-" {                   // never true with these fixtures
    assert_ne!(azure_country, "-");
}
```

## What changed

The lookups use `89.160.20.112`, which the checked-in fixtures resolve in all three databases (ASN `Bredband2 AB`, city `Linköping`, country `Sweden`). The guard is gone and the assertions name concrete values.

The AWS lookup stays as an explicit control carrying a message that points at the fixture:

```rust
assert_eq!(
    lookup("SrcCountry", &aws_event, ".sourceIPAddress", &mut geo),
    "Sweden",
    "the control lookup must enrich; is 89.160.20.112 still in test_files/mmdb?"
);
```

so if the databases are ever swapped the test says *why* it broke instead of quietly going vacuous again.

Coverage also widened past the single `SrcCountry` lookup:

- all three geo columns, since they are three separate lookups against three separate databases;
- a `|`-separated spec where the field actually present is **not** the first candidate (the real Azure/M365 profile is `.claims.ipaddr|.callerIpAddress|.ClientIP|.ActorIpAddress`, and Azure activity logs frequently carry `callerIpAddress` without `claims.ipaddr`);
- an empty spec — a profile with no `SrcIP` column;
- an event carrying none of the spec's candidates, which must yield `-` rather than enriching from an unrelated field.

## Verification

Mutation-tested, each run against the previous test and this one:

| mutation | before | after |
|---|---|---|
| hardcode `sourceIPAddress` (the #159 bug) | passed | **fails** — `left: "-", right: "Sweden"` |
| take only the first candidate, don't walk the `\|` list | passed | **fails** |
| ignore the profile spec, use a fixed candidate list | passed | **fails** |

186 tests pass; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

## On #159 itself

The production fix from #171 is correct and I confirmed it end to end rather than from the code — `azure-timeline` with `callerIpAddress` `89.160.20.112` and `-G test_files/mmdb` enriches to `Bredband2 AB` / `Linköping` / `Sweden`, where `main` before #171 produced `-`. **#159 can be closed**; it appears to have stayed open only because #171 did not reference it in a closing keyword.

## Noticed while testing, filed separately

`2001:218::1` and `240d:1a:7fe:a000:…` are reported as `SrcASN: Private`. Both are global unicast (`2000::/3`), not private. hayabusa had the same bug and fixed it by removing `2000::/3` and `FD00::/8` from its private-range list. Not touched here.
